### PR TITLE
chore: add ktlint for Kotlin formatting enforcement

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.{kt,kts}]
+# Compose @Composable functions use PascalCase by convention
+ktlint_function_naming_ignore_when_annotated_with = Composable

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x gradlew
 
+      - name: Kotlin formatting check
+        run: ./gradlew ktlintCheck
+
       - name: Lint
         run: ./gradlew lintDebug
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,7 +40,7 @@ android {
             signingConfig = signingConfigs.findByName("release")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
+                "proguard-rules.pro",
             )
         }
     }

--- a/app/src/main/java/com/rehearsall/MainActivity.kt
+++ b/app/src/main/java/com/rehearsall/MainActivity.kt
@@ -18,7 +18,6 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
-
     @Inject
     lateinit var userPreferencesRepository: UserPreferencesRepository
 
@@ -32,11 +31,12 @@ class MainActivity : ComponentActivity() {
             val themeMode by userPreferencesRepository.themeMode
                 .collectAsStateWithLifecycle(initialValue = ThemeMode.SYSTEM)
 
-            val darkTheme = when (themeMode) {
-                ThemeMode.LIGHT -> false
-                ThemeMode.DARK -> true
-                ThemeMode.SYSTEM -> isSystemInDarkTheme()
-            }
+            val darkTheme =
+                when (themeMode) {
+                    ThemeMode.LIGHT -> false
+                    ThemeMode.DARK -> true
+                    ThemeMode.SYSTEM -> isSystemInDarkTheme()
+                }
 
             RehearsAllTheme(darkTheme = darkTheme) {
                 RehearsAllNavGraph(windowSizeClass = windowSizeClass)

--- a/app/src/main/java/com/rehearsall/RehearsAllApp.kt
+++ b/app/src/main/java/com/rehearsall/RehearsAllApp.kt
@@ -1,13 +1,12 @@
 package com.rehearsall
 
 import android.app.Application
+import com.rehearsall.logging.FileLoggingTree
 import dagger.hilt.android.HiltAndroidApp
 import timber.log.Timber
-import com.rehearsall.logging.FileLoggingTree
 
 @HiltAndroidApp
 class RehearsAllApp : Application() {
-
     override fun onCreate() {
         super.onCreate()
 

--- a/app/src/main/java/com/rehearsall/data/audio/AudioImporter.kt
+++ b/app/src/main/java/com/rehearsall/data/audio/AudioImporter.kt
@@ -18,137 +18,154 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class AudioImporter @Inject constructor(
-    @ApplicationContext private val context: Context,
-    private val repository: AudioFileRepository,
-    private val waveformRepository: WaveformRepository,
-) {
-    companion object {
-        private val SUPPORTED_FORMATS = setOf("mp3", "wav", "ogg", "flac", "m4a", "aac")
-        private const val MAX_FILE_SIZE_BYTES = 500L * 1024 * 1024 // 500MB
-    }
+class AudioImporter
+    @Inject
+    constructor(
+        @ApplicationContext private val context: Context,
+        private val repository: AudioFileRepository,
+        private val waveformRepository: WaveformRepository,
+    ) {
+        companion object {
+            private val SUPPORTED_FORMATS = setOf("mp3", "wav", "ogg", "flac", "m4a", "aac")
+            private const val MAX_FILE_SIZE_BYTES = 500L * 1024 * 1024 // 500MB
+        }
 
-    suspend fun import(uri: Uri): Result<AudioFile> = withContext(Dispatchers.IO) {
-        try {
-            val fileName = getFileName(uri)
-                ?: return@withContext Result.failure(ImportError.UnknownFileName)
+        suspend fun import(uri: Uri): Result<AudioFile> =
+            withContext(Dispatchers.IO) {
+                try {
+                    val fileName =
+                        getFileName(uri)
+                            ?: return@withContext Result.failure(ImportError.UnknownFileName)
 
-            val extension = fileName.substringAfterLast('.', "").lowercase()
-            if (extension !in SUPPORTED_FORMATS) {
-                Timber.w("Import rejected: unsupported format '%s' for file '%s'", extension, fileName)
-                return@withContext Result.failure(
-                    ImportError.UnsupportedFormat(extension, SUPPORTED_FORMATS)
+                    val extension = fileName.substringAfterLast('.', "").lowercase()
+                    if (extension !in SUPPORTED_FORMATS) {
+                        Timber.w("Import rejected: unsupported format '%s' for file '%s'", extension, fileName)
+                        return@withContext Result.failure(
+                            ImportError.UnsupportedFormat(extension, SUPPORTED_FORMATS),
+                        )
+                    }
+
+                    val fileSize = getFileSize(uri)
+                    if (fileSize > MAX_FILE_SIZE_BYTES) {
+                        Timber.w("Import rejected: file too large (%d bytes) for '%s'", fileSize, fileName)
+                        return@withContext Result.failure(ImportError.FileTooLarge(fileSize, MAX_FILE_SIZE_BYTES))
+                    }
+
+                    // Copy to internal storage with UUID name
+                    val internalFile = copyToInternal(uri, extension)
+
+                    // Extract metadata
+                    val metadata = extractMetadata(internalFile)
+
+                    val displayName =
+                        metadata.title
+                            ?: fileName.substringBeforeLast('.', fileName)
+
+                    val entity =
+                        AudioFileEntity(
+                            fileName = fileName,
+                            displayName = displayName,
+                            internalPath = internalFile.absolutePath,
+                            format = extension,
+                            durationMs = metadata.durationMs,
+                            fileSizeBytes = fileSize,
+                            artist = metadata.artist,
+                            title = metadata.title,
+                            importedAt = System.currentTimeMillis(),
+                            lastPlayedAt = null,
+                        )
+
+                    val id = repository.insert(entity)
+                    val audioFile =
+                        repository.getById(id)
+                            ?: return@withContext Result.failure(ImportError.DatabaseError)
+
+                    Timber.i(
+                        "Imported '%s' (id=%d, format=%s, duration=%dms, size=%d bytes)",
+                        displayName,
+                        id,
+                        extension,
+                        metadata.durationMs,
+                        fileSize,
+                    )
+
+                    // Extract waveform in background (non-blocking)
+                    try {
+                        waveformRepository.ensureCached(id, internalFile.absolutePath)
+                    } catch (e: Exception) {
+                        Timber.w(e, "Waveform extraction failed for '%s', will retry on playback", displayName)
+                    }
+
+                    Result.success(audioFile)
+                } catch (e: Exception) {
+                    Timber.e(e, "Import failed")
+                    Result.failure(ImportError.Unknown(e))
+                }
+            }
+
+        private fun getFileName(uri: Uri): String? {
+            context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+                if (cursor.moveToFirst()) {
+                    val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                    if (nameIndex >= 0) {
+                        return cursor.getString(nameIndex)
+                    }
+                }
+            }
+            return uri.lastPathSegment
+        }
+
+        private fun getFileSize(uri: Uri): Long {
+            context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+                if (cursor.moveToFirst()) {
+                    val sizeIndex = cursor.getColumnIndex(OpenableColumns.SIZE)
+                    if (sizeIndex >= 0) {
+                        return cursor.getLong(sizeIndex)
+                    }
+                }
+            }
+            return 0L
+        }
+
+        private fun copyToInternal(
+            uri: Uri,
+            extension: String,
+        ): File {
+            val audioDir = File(context.filesDir, "audio")
+            audioDir.mkdirs()
+            val destFile = File(audioDir, "${UUID.randomUUID()}.$extension")
+
+            context.contentResolver.openInputStream(uri)?.use { input ->
+                destFile.outputStream().use { output ->
+                    input.copyTo(output)
+                }
+            } ?: throw ImportError.CopyFailed
+
+            return destFile
+        }
+
+        private fun extractMetadata(file: File): AudioMetadata {
+            val retriever = MediaMetadataRetriever()
+            return try {
+                retriever.setDataSource(file.absolutePath)
+                AudioMetadata(
+                    durationMs =
+                        retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
+                            ?.toLongOrNull() ?: 0L,
+                    artist = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ARTIST),
+                    title = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_TITLE),
                 )
-            }
-
-            val fileSize = getFileSize(uri)
-            if (fileSize > MAX_FILE_SIZE_BYTES) {
-                Timber.w("Import rejected: file too large (%d bytes) for '%s'", fileSize, fileName)
-                return@withContext Result.failure(ImportError.FileTooLarge(fileSize, MAX_FILE_SIZE_BYTES))
-            }
-
-            // Copy to internal storage with UUID name
-            val internalFile = copyToInternal(uri, extension)
-
-            // Extract metadata
-            val metadata = extractMetadata(internalFile)
-
-            val displayName = metadata.title
-                ?: fileName.substringBeforeLast('.', fileName)
-
-            val entity = AudioFileEntity(
-                fileName = fileName,
-                displayName = displayName,
-                internalPath = internalFile.absolutePath,
-                format = extension,
-                durationMs = metadata.durationMs,
-                fileSizeBytes = fileSize,
-                artist = metadata.artist,
-                title = metadata.title,
-                importedAt = System.currentTimeMillis(),
-                lastPlayedAt = null,
-            )
-
-            val id = repository.insert(entity)
-            val audioFile = repository.getById(id)
-                ?: return@withContext Result.failure(ImportError.DatabaseError)
-
-            Timber.i("Imported '%s' (id=%d, format=%s, duration=%dms, size=%d bytes)",
-                displayName, id, extension, metadata.durationMs, fileSize)
-
-            // Extract waveform in background (non-blocking)
-            try {
-                waveformRepository.ensureCached(id, internalFile.absolutePath)
-            } catch (e: Exception) {
-                Timber.w(e, "Waveform extraction failed for '%s', will retry on playback", displayName)
-            }
-
-            Result.success(audioFile)
-        } catch (e: Exception) {
-            Timber.e(e, "Import failed")
-            Result.failure(ImportError.Unknown(e))
-        }
-    }
-
-    private fun getFileName(uri: Uri): String? {
-        context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
-            if (cursor.moveToFirst()) {
-                val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
-                if (nameIndex >= 0) {
-                    return cursor.getString(nameIndex)
-                }
+            } finally {
+                retriever.release()
             }
         }
-        return uri.lastPathSegment
+
+        private data class AudioMetadata(
+            val durationMs: Long,
+            val artist: String?,
+            val title: String?,
+        )
     }
-
-    private fun getFileSize(uri: Uri): Long {
-        context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
-            if (cursor.moveToFirst()) {
-                val sizeIndex = cursor.getColumnIndex(OpenableColumns.SIZE)
-                if (sizeIndex >= 0) {
-                    return cursor.getLong(sizeIndex)
-                }
-            }
-        }
-        return 0L
-    }
-
-    private fun copyToInternal(uri: Uri, extension: String): File {
-        val audioDir = File(context.filesDir, "audio")
-        audioDir.mkdirs()
-        val destFile = File(audioDir, "${UUID.randomUUID()}.$extension")
-
-        context.contentResolver.openInputStream(uri)?.use { input ->
-            destFile.outputStream().use { output ->
-                input.copyTo(output)
-            }
-        } ?: throw ImportError.CopyFailed
-
-        return destFile
-    }
-
-    private fun extractMetadata(file: File): AudioMetadata {
-        val retriever = MediaMetadataRetriever()
-        return try {
-            retriever.setDataSource(file.absolutePath)
-            AudioMetadata(
-                durationMs = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
-                    ?.toLongOrNull() ?: 0L,
-                artist = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ARTIST),
-                title = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_TITLE),
-            )
-        } finally {
-            retriever.release()
-        }
-    }
-
-    private data class AudioMetadata(
-        val durationMs: Long,
-        val artist: String?,
-        val title: String?,
-    )
-}
 
 sealed class ImportError : Exception() {
     data object UnknownFileName : ImportError() {

--- a/app/src/main/java/com/rehearsall/data/audio/WaveformCache.kt
+++ b/app/src/main/java/com/rehearsall/data/audio/WaveformCache.kt
@@ -16,80 +16,87 @@ import javax.inject.Singleton
  * Format: magic (4 bytes "WAVE"), version (1 byte), count (4 bytes), floats...
  */
 @Singleton
-class WaveformCache @Inject constructor(
-    @ApplicationContext private val context: Context,
-) {
-    companion object {
-        private val MAGIC = byteArrayOf('W'.code.toByte(), 'A'.code.toByte(), 'V'.code.toByte(), 'E'.code.toByte())
-        private const val VERSION: Byte = 1
-    }
+class WaveformCache
+    @Inject
+    constructor(
+        @ApplicationContext private val context: Context,
+    ) {
+        companion object {
+            private val MAGIC = byteArrayOf('W'.code.toByte(), 'A'.code.toByte(), 'V'.code.toByte(), 'E'.code.toByte())
+            private const val VERSION: Byte = 1
+        }
 
-    private val cacheDir: File
-        get() = File(context.filesDir, "waveforms").also { it.mkdirs() }
+        private val cacheDir: File
+            get() = File(context.filesDir, "waveforms").also { it.mkdirs() }
 
-    fun getCacheFile(audioFileId: Long): File = File(cacheDir, "$audioFileId.waveform")
+        fun getCacheFile(audioFileId: Long): File = File(cacheDir, "$audioFileId.waveform")
 
-    fun isCached(audioFileId: Long): Boolean = getCacheFile(audioFileId).exists()
+        fun isCached(audioFileId: Long): Boolean = getCacheFile(audioFileId).exists()
 
-    suspend fun save(audioFileId: Long, amplitudes: FloatArray) = withContext(Dispatchers.IO) {
-        try {
-            val file = getCacheFile(audioFileId)
-            DataOutputStream(file.outputStream().buffered()).use { out ->
-                out.write(MAGIC)
-                out.writeByte(VERSION.toInt())
-                out.writeInt(amplitudes.size)
-                for (amp in amplitudes) {
-                    out.writeFloat(amp)
+        suspend fun save(
+            audioFileId: Long,
+            amplitudes: FloatArray,
+        ) = withContext(Dispatchers.IO) {
+            try {
+                val file = getCacheFile(audioFileId)
+                DataOutputStream(file.outputStream().buffered()).use { out ->
+                    out.write(MAGIC)
+                    out.writeByte(VERSION.toInt())
+                    out.writeInt(amplitudes.size)
+                    for (amp in amplitudes) {
+                        out.writeFloat(amp)
+                    }
+                }
+                Timber.d("Waveform cached for id=%d (%d samples)", audioFileId, amplitudes.size)
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to cache waveform for id=%d", audioFileId)
+            }
+        }
+
+        suspend fun load(audioFileId: Long): FloatArray? =
+            withContext(Dispatchers.IO) {
+                val file = getCacheFile(audioFileId)
+                if (!file.exists()) return@withContext null
+
+                try {
+                    DataInputStream(file.inputStream().buffered()).use { input ->
+                        // Validate magic
+                        val magic = ByteArray(4)
+                        input.readFully(magic)
+                        if (!magic.contentEquals(MAGIC)) {
+                            Timber.w("Invalid waveform cache magic for id=%d", audioFileId)
+                            file.delete()
+                            return@withContext null
+                        }
+
+                        // Validate version
+                        val version = input.readByte()
+                        if (version != VERSION) {
+                            Timber.w("Unsupported waveform cache version %d for id=%d", version, audioFileId)
+                            file.delete()
+                            return@withContext null
+                        }
+
+                        val count = input.readInt()
+                        if (count <= 0 || count > 1_000_000) {
+                            Timber.w("Invalid waveform sample count %d for id=%d", count, audioFileId)
+                            file.delete()
+                            return@withContext null
+                        }
+
+                        val amplitudes = FloatArray(count) { input.readFloat() }
+                        Timber.d("Waveform loaded from cache for id=%d (%d samples)", audioFileId, count)
+                        amplitudes
+                    }
+                } catch (e: Exception) {
+                    Timber.e(e, "Failed to load waveform cache for id=%d", audioFileId)
+                    file.delete()
+                    null
                 }
             }
-            Timber.d("Waveform cached for id=%d (%d samples)", audioFileId, amplitudes.size)
-        } catch (e: Exception) {
-            Timber.e(e, "Failed to cache waveform for id=%d", audioFileId)
-        }
-    }
 
-    suspend fun load(audioFileId: Long): FloatArray? = withContext(Dispatchers.IO) {
-        val file = getCacheFile(audioFileId)
-        if (!file.exists()) return@withContext null
-
-        try {
-            DataInputStream(file.inputStream().buffered()).use { input ->
-                // Validate magic
-                val magic = ByteArray(4)
-                input.readFully(magic)
-                if (!magic.contentEquals(MAGIC)) {
-                    Timber.w("Invalid waveform cache magic for id=%d", audioFileId)
-                    file.delete()
-                    return@withContext null
-                }
-
-                // Validate version
-                val version = input.readByte()
-                if (version != VERSION) {
-                    Timber.w("Unsupported waveform cache version %d for id=%d", version, audioFileId)
-                    file.delete()
-                    return@withContext null
-                }
-
-                val count = input.readInt()
-                if (count <= 0 || count > 1_000_000) {
-                    Timber.w("Invalid waveform sample count %d for id=%d", count, audioFileId)
-                    file.delete()
-                    return@withContext null
-                }
-
-                val amplitudes = FloatArray(count) { input.readFloat() }
-                Timber.d("Waveform loaded from cache for id=%d (%d samples)", audioFileId, count)
-                amplitudes
+        suspend fun delete(audioFileId: Long) =
+            withContext(Dispatchers.IO) {
+                getCacheFile(audioFileId).delete()
             }
-        } catch (e: Exception) {
-            Timber.e(e, "Failed to load waveform cache for id=%d", audioFileId)
-            file.delete()
-            null
-        }
     }
-
-    suspend fun delete(audioFileId: Long) = withContext(Dispatchers.IO) {
-        getCacheFile(audioFileId).delete()
-    }
-}

--- a/app/src/main/java/com/rehearsall/data/audio/WaveformExtractor.kt
+++ b/app/src/main/java/com/rehearsall/data/audio/WaveformExtractor.kt
@@ -7,12 +7,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
 import timber.log.Timber
-import java.io.File
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.math.abs
 import kotlin.math.sqrt
 
 /**
@@ -20,157 +18,167 @@ import kotlin.math.sqrt
  * MediaExtractor + MediaCodec. Produces one RMS amplitude sample per ~10ms window.
  */
 @Singleton
-class WaveformExtractor @Inject constructor() {
+class WaveformExtractor
+    @Inject
+    constructor() {
+        companion object {
+            private const val WINDOW_MS = 10L // ~10ms per amplitude sample
+        }
 
-    companion object {
-        private const val WINDOW_MS = 10L // ~10ms per amplitude sample
-    }
+        /**
+         * Extract waveform amplitudes from an audio file.
+         * Returns a FloatArray of normalized amplitudes (0.0–1.0), one per 10ms window.
+         */
+        suspend fun extract(filePath: String): Result<FloatArray> =
+            withContext(Dispatchers.Default) {
+                val extractor = MediaExtractor()
+                try {
+                    extractor.setDataSource(filePath)
 
-    /**
-     * Extract waveform amplitudes from an audio file.
-     * Returns a FloatArray of normalized amplitudes (0.0–1.0), one per 10ms window.
-     */
-    suspend fun extract(filePath: String): Result<FloatArray> = withContext(Dispatchers.Default) {
-        val extractor = MediaExtractor()
-        try {
-            extractor.setDataSource(filePath)
+                    // Find audio track
+                    val audioTrackIndex =
+                        (0 until extractor.trackCount).firstOrNull { i ->
+                            extractor.getTrackFormat(i).getString(MediaFormat.KEY_MIME)
+                                ?.startsWith("audio/") == true
+                        } ?: return@withContext Result.failure(
+                            IllegalArgumentException("No audio track found in $filePath"),
+                        )
 
-            // Find audio track
-            val audioTrackIndex = (0 until extractor.trackCount).firstOrNull { i ->
-                extractor.getTrackFormat(i).getString(MediaFormat.KEY_MIME)
-                    ?.startsWith("audio/") == true
-            } ?: return@withContext Result.failure(
-                IllegalArgumentException("No audio track found in $filePath")
-            )
+                    extractor.selectTrack(audioTrackIndex)
+                    val format = extractor.getTrackFormat(audioTrackIndex)
 
-            extractor.selectTrack(audioTrackIndex)
-            val format = extractor.getTrackFormat(audioTrackIndex)
+                    val sampleRate = format.getInteger(MediaFormat.KEY_SAMPLE_RATE)
+                    val channelCount = format.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
+                    val durationUs = format.getLong(MediaFormat.KEY_DURATION)
 
-            val sampleRate = format.getInteger(MediaFormat.KEY_SAMPLE_RATE)
-            val channelCount = format.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
-            val durationUs = format.getLong(MediaFormat.KEY_DURATION)
+                    // Samples per window
+                    val samplesPerWindow = (sampleRate * WINDOW_MS / 1000).toInt()
+                    val totalWindows = ((durationUs / 1000) / WINDOW_MS).toInt().coerceAtLeast(1)
 
-            // Samples per window
-            val samplesPerWindow = (sampleRate * WINDOW_MS / 1000).toInt()
-            val totalWindows = ((durationUs / 1000) / WINDOW_MS).toInt().coerceAtLeast(1)
+                    val amplitudes = mutableListOf<Float>()
+                    val mime = format.getString(MediaFormat.KEY_MIME)!!
 
-            val amplitudes = mutableListOf<Float>()
-            val mime = format.getString(MediaFormat.KEY_MIME)!!
+                    val codec = MediaCodec.createDecoderByType(mime)
+                    codec.configure(format, null, null, 0)
+                    codec.start()
 
-            val codec = MediaCodec.createDecoderByType(mime)
-            codec.configure(format, null, null, 0)
-            codec.start()
+                    val bufferInfo = MediaCodec.BufferInfo()
+                    var inputDone = false
+                    var outputDone = false
+                    var accumulatedSquares = 0.0
+                    var samplesInWindow = 0
+                    var maxAmplitude = 0f
 
-            val bufferInfo = MediaCodec.BufferInfo()
-            var inputDone = false
-            var outputDone = false
-            var accumulatedSquares = 0.0
-            var samplesInWindow = 0
-            var maxAmplitude = 0f
+                    while (!outputDone && isActive) {
+                        // Feed input
+                        if (!inputDone) {
+                            val inputIndex = codec.dequeueInputBuffer(10_000)
+                            if (inputIndex >= 0) {
+                                val inputBuffer = codec.getInputBuffer(inputIndex)!!
+                                val sampleSize = extractor.readSampleData(inputBuffer, 0)
+                                if (sampleSize < 0) {
+                                    codec.queueInputBuffer(
+                                        inputIndex,
+                                        0,
+                                        0,
+                                        0,
+                                        MediaCodec.BUFFER_FLAG_END_OF_STREAM,
+                                    )
+                                    inputDone = true
+                                } else {
+                                    codec.queueInputBuffer(
+                                        inputIndex,
+                                        0,
+                                        sampleSize,
+                                        extractor.sampleTime,
+                                        0,
+                                    )
+                                    extractor.advance()
+                                }
+                            }
+                        }
 
-            while (!outputDone && isActive) {
-                // Feed input
-                if (!inputDone) {
-                    val inputIndex = codec.dequeueInputBuffer(10_000)
-                    if (inputIndex >= 0) {
-                        val inputBuffer = codec.getInputBuffer(inputIndex)!!
-                        val sampleSize = extractor.readSampleData(inputBuffer, 0)
-                        if (sampleSize < 0) {
-                            codec.queueInputBuffer(
-                                inputIndex, 0, 0, 0,
-                                MediaCodec.BUFFER_FLAG_END_OF_STREAM,
-                            )
-                            inputDone = true
+                        // Read output (decoded PCM)
+                        val outputIndex = codec.dequeueOutputBuffer(bufferInfo, 10_000)
+                        if (outputIndex >= 0) {
+                            val outputBuffer = codec.getOutputBuffer(outputIndex)!!
+                            val pcmData = processPcmBuffer(outputBuffer, bufferInfo.size, channelCount)
+
+                            for (sample in pcmData) {
+                                accumulatedSquares += sample * sample
+                                samplesInWindow++
+
+                                if (samplesInWindow >= samplesPerWindow) {
+                                    val rms = sqrt(accumulatedSquares / samplesInWindow).toFloat()
+                                    amplitudes.add(rms)
+                                    if (rms > maxAmplitude) maxAmplitude = rms
+                                    accumulatedSquares = 0.0
+                                    samplesInWindow = 0
+                                }
+                            }
+
+                            codec.releaseOutputBuffer(outputIndex, false)
+
+                            if (bufferInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM != 0) {
+                                outputDone = true
+                            }
+                        }
+                    }
+
+                    // Flush remaining samples
+                    if (samplesInWindow > 0) {
+                        val rms = sqrt(accumulatedSquares / samplesInWindow).toFloat()
+                        amplitudes.add(rms)
+                        if (rms > maxAmplitude) maxAmplitude = rms
+                    }
+
+                    codec.stop()
+                    codec.release()
+
+                    // Normalize to 0.0–1.0
+                    val result =
+                        if (maxAmplitude > 0f) {
+                            FloatArray(amplitudes.size) { (amplitudes[it] / maxAmplitude).coerceIn(0f, 1f) }
                         } else {
-                            codec.queueInputBuffer(
-                                inputIndex, 0, sampleSize,
-                                extractor.sampleTime, 0,
-                            )
-                            extractor.advance()
+                            FloatArray(amplitudes.size) { 0f }
                         }
-                    }
-                }
 
-                // Read output (decoded PCM)
-                val outputIndex = codec.dequeueOutputBuffer(bufferInfo, 10_000)
-                if (outputIndex >= 0) {
-                    val outputBuffer = codec.getOutputBuffer(outputIndex)!!
-                    val pcmData = processPcmBuffer(outputBuffer, bufferInfo.size, channelCount)
-
-                    for (sample in pcmData) {
-                        accumulatedSquares += sample * sample
-                        samplesInWindow++
-
-                        if (samplesInWindow >= samplesPerWindow) {
-                            val rms = sqrt(accumulatedSquares / samplesInWindow).toFloat()
-                            amplitudes.add(rms)
-                            if (rms > maxAmplitude) maxAmplitude = rms
-                            accumulatedSquares = 0.0
-                            samplesInWindow = 0
-                        }
-                    }
-
-                    codec.releaseOutputBuffer(outputIndex, false)
-
-                    if (bufferInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM != 0) {
-                        outputDone = true
-                    }
+                    Timber.i("Waveform extracted: %d samples from %s", result.size, filePath)
+                    Result.success(result)
+                } catch (e: Exception) {
+                    Timber.e(e, "Waveform extraction failed for %s", filePath)
+                    Result.failure(e)
+                } finally {
+                    extractor.release()
                 }
             }
 
-            // Flush remaining samples
-            if (samplesInWindow > 0) {
-                val rms = sqrt(accumulatedSquares / samplesInWindow).toFloat()
-                amplitudes.add(rms)
-                if (rms > maxAmplitude) maxAmplitude = rms
+        /**
+         * Convert PCM buffer to mono float samples normalized to -1.0..1.0.
+         * Assumes 16-bit PCM (standard MediaCodec output).
+         */
+        private fun processPcmBuffer(
+            buffer: ByteBuffer,
+            size: Int,
+            channelCount: Int,
+        ): FloatArray {
+            buffer.order(ByteOrder.LITTLE_ENDIAN)
+            buffer.rewind()
+
+            val shortCount = size / 2
+            val monoSamples = shortCount / channelCount
+
+            return FloatArray(monoSamples) { i ->
+                // Average across channels
+                var sum = 0f
+                for (ch in 0 until channelCount) {
+                    val pos = (i * channelCount + ch) * 2
+                    if (pos + 1 < size) {
+                        val sample = buffer.getShort(pos)
+                        sum += sample.toFloat() / Short.MAX_VALUE
+                    }
+                }
+                sum / channelCount
             }
-
-            codec.stop()
-            codec.release()
-
-            // Normalize to 0.0–1.0
-            val result = if (maxAmplitude > 0f) {
-                FloatArray(amplitudes.size) { (amplitudes[it] / maxAmplitude).coerceIn(0f, 1f) }
-            } else {
-                FloatArray(amplitudes.size) { 0f }
-            }
-
-            Timber.i("Waveform extracted: %d samples from %s", result.size, filePath)
-            Result.success(result)
-        } catch (e: Exception) {
-            Timber.e(e, "Waveform extraction failed for %s", filePath)
-            Result.failure(e)
-        } finally {
-            extractor.release()
         }
     }
-
-    /**
-     * Convert PCM buffer to mono float samples normalized to -1.0..1.0.
-     * Assumes 16-bit PCM (standard MediaCodec output).
-     */
-    private fun processPcmBuffer(
-        buffer: ByteBuffer,
-        size: Int,
-        channelCount: Int,
-    ): FloatArray {
-        buffer.order(ByteOrder.LITTLE_ENDIAN)
-        buffer.rewind()
-
-        val shortCount = size / 2
-        val monoSamples = shortCount / channelCount
-
-        return FloatArray(monoSamples) { i ->
-            // Average across channels
-            var sum = 0f
-            for (ch in 0 until channelCount) {
-                val pos = (i * channelCount + ch) * 2
-                if (pos + 1 < size) {
-                    val sample = buffer.getShort(pos)
-                    sum += sample.toFloat() / Short.MAX_VALUE
-                }
-            }
-            sum / channelCount
-        }
-    }
-}

--- a/app/src/main/java/com/rehearsall/data/db/RehearsAllDatabase.kt
+++ b/app/src/main/java/com/rehearsall/data/db/RehearsAllDatabase.kt
@@ -32,10 +32,16 @@ import com.rehearsall.data.db.entity.PracticeSettingsEntity
 )
 abstract class RehearsAllDatabase : RoomDatabase() {
     abstract fun audioFileDao(): AudioFileDao
+
     abstract fun playlistDao(): PlaylistDao
+
     abstract fun playlistItemDao(): PlaylistItemDao
+
     abstract fun bookmarkDao(): BookmarkDao
+
     abstract fun loopDao(): LoopDao
+
     abstract fun chunkMarkerDao(): ChunkMarkerDao
+
     abstract fun practiceSettingsDao(): PracticeSettingsDao
 }

--- a/app/src/main/java/com/rehearsall/data/db/dao/AudioFileDao.kt
+++ b/app/src/main/java/com/rehearsall/data/db/dao/AudioFileDao.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface AudioFileDao {
-
     @Insert
     suspend fun insert(entity: AudioFileEntity): Long
 
@@ -20,7 +19,7 @@ interface AudioFileDao {
 
     @Query(
         "SELECT * FROM audio_files WHERE lastPlayedAt IS NOT NULL " +
-            "ORDER BY lastPlayedAt DESC LIMIT :limit"
+            "ORDER BY lastPlayedAt DESC LIMIT :limit",
     )
     fun getRecent(limit: Int = 20): Flow<List<AudioFileEntity>>
 
@@ -29,7 +28,7 @@ interface AudioFileDao {
 
     @Query(
         "SELECT * FROM audio_files WHERE lastPlayedAt IS NOT NULL " +
-            "ORDER BY lastPlayedAt DESC LIMIT :limit"
+            "ORDER BY lastPlayedAt DESC LIMIT :limit",
     )
     suspend fun getRecentList(limit: Int = 20): List<AudioFileEntity>
 
@@ -37,17 +36,30 @@ interface AudioFileDao {
     suspend fun delete(id: Long)
 
     @Query("UPDATE audio_files SET displayName = :displayName WHERE id = :id")
-    suspend fun updateDisplayName(id: Long, displayName: String)
+    suspend fun updateDisplayName(
+        id: Long,
+        displayName: String,
+    )
 
     @Query(
         "UPDATE audio_files SET lastPlayedAt = :lastPlayedAt, lastPositionMs = :lastPositionMs " +
-            "WHERE id = :id"
+            "WHERE id = :id",
     )
-    suspend fun updateLastPlayed(id: Long, lastPlayedAt: Long, lastPositionMs: Long)
+    suspend fun updateLastPlayed(
+        id: Long,
+        lastPlayedAt: Long,
+        lastPositionMs: Long,
+    )
 
     @Query("UPDATE audio_files SET lastPositionMs = :positionMs WHERE id = :id")
-    suspend fun updateLastPosition(id: Long, positionMs: Long)
+    suspend fun updateLastPosition(
+        id: Long,
+        positionMs: Long,
+    )
 
     @Query("UPDATE audio_files SET lastSpeed = :speed WHERE id = :id")
-    suspend fun updateLastSpeed(id: Long, speed: Float)
+    suspend fun updateLastSpeed(
+        id: Long,
+        speed: Float,
+    )
 }

--- a/app/src/main/java/com/rehearsall/data/db/dao/BookmarkDao.kt
+++ b/app/src/main/java/com/rehearsall/data/db/dao/BookmarkDao.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface BookmarkDao {
-
     @Insert
     suspend fun insert(entity: BookmarkEntity): Long
 
@@ -19,10 +18,16 @@ interface BookmarkDao {
     suspend fun getById(id: Long): BookmarkEntity?
 
     @Query("UPDATE bookmarks SET name = :name WHERE id = :id")
-    suspend fun updateName(id: Long, name: String)
+    suspend fun updateName(
+        id: Long,
+        name: String,
+    )
 
     @Query("UPDATE bookmarks SET positionMs = :positionMs WHERE id = :id")
-    suspend fun updatePosition(id: Long, positionMs: Long)
+    suspend fun updatePosition(
+        id: Long,
+        positionMs: Long,
+    )
 
     @Query("DELETE FROM bookmarks WHERE id = :id")
     suspend fun delete(id: Long)

--- a/app/src/main/java/com/rehearsall/data/db/dao/ChunkMarkerDao.kt
+++ b/app/src/main/java/com/rehearsall/data/db/dao/ChunkMarkerDao.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface ChunkMarkerDao {
-
     @Insert
     suspend fun insert(marker: ChunkMarkerEntity): Long
 
@@ -16,10 +15,16 @@ interface ChunkMarkerDao {
     fun getAllForFile(audioFileId: Long): Flow<List<ChunkMarkerEntity>>
 
     @Query("UPDATE chunk_markers SET label = :label WHERE id = :id")
-    suspend fun updateLabel(id: Long, label: String)
+    suspend fun updateLabel(
+        id: Long,
+        label: String,
+    )
 
     @Query("UPDATE chunk_markers SET positionMs = :positionMs WHERE id = :id")
-    suspend fun updatePosition(id: Long, positionMs: Long)
+    suspend fun updatePosition(
+        id: Long,
+        positionMs: Long,
+    )
 
     @Query("DELETE FROM chunk_markers WHERE id = :id")
     suspend fun delete(id: Long)

--- a/app/src/main/java/com/rehearsall/data/db/dao/LoopDao.kt
+++ b/app/src/main/java/com/rehearsall/data/db/dao/LoopDao.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface LoopDao {
-
     @Insert
     suspend fun insert(loop: LoopEntity): Long
 
@@ -22,10 +21,17 @@ interface LoopDao {
     suspend fun getById(id: Long): LoopEntity?
 
     @Query("UPDATE loops SET name = :name WHERE id = :id")
-    suspend fun updateName(id: Long, name: String)
+    suspend fun updateName(
+        id: Long,
+        name: String,
+    )
 
     @Query("UPDATE loops SET startMs = :startMs, endMs = :endMs WHERE id = :id")
-    suspend fun updateRegion(id: Long, startMs: Long, endMs: Long)
+    suspend fun updateRegion(
+        id: Long,
+        startMs: Long,
+        endMs: Long,
+    )
 
     @Query("DELETE FROM loops WHERE id = :id")
     suspend fun delete(id: Long)

--- a/app/src/main/java/com/rehearsall/data/db/dao/PlaylistDao.kt
+++ b/app/src/main/java/com/rehearsall/data/db/dao/PlaylistDao.kt
@@ -3,13 +3,11 @@ package com.rehearsall.data.db.dao
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.Query
-import androidx.room.Transaction
 import com.rehearsall.data.db.entity.PlaylistEntity
 import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface PlaylistDao {
-
     @Insert
     suspend fun insert(entity: PlaylistEntity): Long
 
@@ -23,10 +21,17 @@ interface PlaylistDao {
     suspend fun getById(id: Long): PlaylistEntity?
 
     @Query("UPDATE playlists SET name = :name, updatedAt = :updatedAt WHERE id = :id")
-    suspend fun updateName(id: Long, name: String, updatedAt: Long = System.currentTimeMillis())
+    suspend fun updateName(
+        id: Long,
+        name: String,
+        updatedAt: Long = System.currentTimeMillis(),
+    )
 
     @Query("UPDATE playlists SET updatedAt = :updatedAt WHERE id = :id")
-    suspend fun touch(id: Long, updatedAt: Long = System.currentTimeMillis())
+    suspend fun touch(
+        id: Long,
+        updatedAt: Long = System.currentTimeMillis(),
+    )
 
     @Query("DELETE FROM playlists WHERE id = :id")
     suspend fun delete(id: Long)

--- a/app/src/main/java/com/rehearsall/data/db/dao/PlaylistItemDao.kt
+++ b/app/src/main/java/com/rehearsall/data/db/dao/PlaylistItemDao.kt
@@ -3,13 +3,11 @@ package com.rehearsall.data.db.dao
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.Query
-import com.rehearsall.data.db.entity.AudioFileEntity
 import com.rehearsall.data.db.entity.PlaylistItemEntity
 import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface PlaylistItemDao {
-
     @Insert
     suspend fun insert(entity: PlaylistItemEntity): Long
 
@@ -20,7 +18,7 @@ interface PlaylistItemDao {
         "SELECT pi.*, af.* FROM playlist_items pi " +
             "INNER JOIN audio_files af ON pi.audioFileId = af.id " +
             "WHERE pi.playlistId = :playlistId " +
-            "ORDER BY pi.orderIndex ASC"
+            "ORDER BY pi.orderIndex ASC",
     )
     fun getItemsWithFiles(playlistId: Long): Flow<List<PlaylistItemWithFile>>
 
@@ -37,7 +35,10 @@ interface PlaylistItemDao {
     suspend fun deleteAllForPlaylist(playlistId: Long)
 
     @Query("UPDATE playlist_items SET orderIndex = :orderIndex WHERE id = :id")
-    suspend fun updateOrder(id: Long, orderIndex: Int)
+    suspend fun updateOrder(
+        id: Long,
+        orderIndex: Int,
+    )
 
     @Query("SELECT COUNT(*) FROM playlist_items WHERE playlistId = :playlistId")
     suspend fun getItemCount(playlistId: Long): Int
@@ -45,7 +46,7 @@ interface PlaylistItemDao {
     @Query(
         "SELECT COALESCE(SUM(af.durationMs), 0) FROM playlist_items pi " +
             "INNER JOIN audio_files af ON pi.audioFileId = af.id " +
-            "WHERE pi.playlistId = :playlistId"
+            "WHERE pi.playlistId = :playlistId",
     )
     suspend fun getTotalDuration(playlistId: Long): Long
 }

--- a/app/src/main/java/com/rehearsall/data/db/dao/PracticeSettingsDao.kt
+++ b/app/src/main/java/com/rehearsall/data/db/dao/PracticeSettingsDao.kt
@@ -8,7 +8,6 @@ import com.rehearsall.data.db.entity.PracticeSettingsEntity
 
 @Dao
 interface PracticeSettingsDao {
-
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertOrUpdate(settings: PracticeSettingsEntity)
 

--- a/app/src/main/java/com/rehearsall/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/rehearsall/data/preferences/UserPreferencesRepository.kt
@@ -17,61 +17,67 @@ import javax.inject.Singleton
  * Reads/writes user preferences via DataStore.
  */
 @Singleton
-class UserPreferencesRepository @Inject constructor(
-    private val dataStore: DataStore<Preferences>,
-) {
-    private companion object {
-        val THEME_MODE = stringPreferencesKey("theme_mode")
-        val SKIP_INCREMENT_MS = longPreferencesKey("skip_increment_ms")
-        val LOOP_CROSSFADE = booleanPreferencesKey("loop_crossfade")
-        val WAVEFORM_OVERLAY = stringPreferencesKey("waveform_overlay")
-    }
+class UserPreferencesRepository
+    @Inject
+    constructor(
+        private val dataStore: DataStore<Preferences>,
+    ) {
+        private companion object {
+            val THEME_MODE = stringPreferencesKey("theme_mode")
+            val SKIP_INCREMENT_MS = longPreferencesKey("skip_increment_ms")
+            val LOOP_CROSSFADE = booleanPreferencesKey("loop_crossfade")
+            val WAVEFORM_OVERLAY = stringPreferencesKey("waveform_overlay")
+        }
 
-    val themeMode: Flow<ThemeMode> = dataStore.data.map { prefs ->
-        when (prefs[THEME_MODE]) {
-            "LIGHT" -> ThemeMode.LIGHT
-            "DARK" -> ThemeMode.DARK
-            else -> ThemeMode.SYSTEM
+        val themeMode: Flow<ThemeMode> =
+            dataStore.data.map { prefs ->
+                when (prefs[THEME_MODE]) {
+                    "LIGHT" -> ThemeMode.LIGHT
+                    "DARK" -> ThemeMode.DARK
+                    else -> ThemeMode.SYSTEM
+                }
+            }
+
+        val skipIncrementMs: Flow<Long> =
+            dataStore.data.map { prefs ->
+                prefs[SKIP_INCREMENT_MS] ?: 5000L
+            }
+
+        val loopCrossfade: Flow<Boolean> =
+            dataStore.data.map { prefs ->
+                prefs[LOOP_CROSSFADE] ?: true
+            }
+
+        val waveformOverlay: Flow<OverlayMode> =
+            dataStore.data.map { prefs ->
+                when (prefs[WAVEFORM_OVERLAY]) {
+                    "LOOPS" -> OverlayMode.LOOPS
+                    "CHUNKS" -> OverlayMode.CHUNKS
+                    else -> OverlayMode.NONE
+                }
+            }
+
+        suspend fun setThemeMode(mode: ThemeMode) {
+            dataStore.edit { prefs ->
+                prefs[THEME_MODE] = mode.name
+            }
+        }
+
+        suspend fun setSkipIncrementMs(ms: Long) {
+            dataStore.edit { prefs ->
+                prefs[SKIP_INCREMENT_MS] = ms
+            }
+        }
+
+        suspend fun setLoopCrossfade(enabled: Boolean) {
+            dataStore.edit { prefs ->
+                prefs[LOOP_CROSSFADE] = enabled
+            }
+        }
+
+        suspend fun setWaveformOverlay(mode: OverlayMode) {
+            dataStore.edit { prefs ->
+                prefs[WAVEFORM_OVERLAY] = mode.name
+            }
         }
     }
-
-    val skipIncrementMs: Flow<Long> = dataStore.data.map { prefs ->
-        prefs[SKIP_INCREMENT_MS] ?: 5000L
-    }
-
-    val loopCrossfade: Flow<Boolean> = dataStore.data.map { prefs ->
-        prefs[LOOP_CROSSFADE] ?: true
-    }
-
-    val waveformOverlay: Flow<OverlayMode> = dataStore.data.map { prefs ->
-        when (prefs[WAVEFORM_OVERLAY]) {
-            "LOOPS" -> OverlayMode.LOOPS
-            "CHUNKS" -> OverlayMode.CHUNKS
-            else -> OverlayMode.NONE
-        }
-    }
-
-    suspend fun setThemeMode(mode: ThemeMode) {
-        dataStore.edit { prefs ->
-            prefs[THEME_MODE] = mode.name
-        }
-    }
-
-    suspend fun setSkipIncrementMs(ms: Long) {
-        dataStore.edit { prefs ->
-            prefs[SKIP_INCREMENT_MS] = ms
-        }
-    }
-
-    suspend fun setLoopCrossfade(enabled: Boolean) {
-        dataStore.edit { prefs ->
-            prefs[LOOP_CROSSFADE] = enabled
-        }
-    }
-
-    suspend fun setWaveformOverlay(mode: OverlayMode) {
-        dataStore.edit { prefs ->
-            prefs[WAVEFORM_OVERLAY] = mode.name
-        }
-    }
-}

--- a/app/src/main/java/com/rehearsall/data/repository/AudioFileRepository.kt
+++ b/app/src/main/java/com/rehearsall/data/repository/AudioFileRepository.kt
@@ -13,72 +13,106 @@ import javax.inject.Singleton
 
 interface AudioFileRepository {
     fun getAllFiles(): Flow<List<AudioFile>>
+
     fun getRecentFiles(limit: Int = 20): Flow<List<AudioFile>>
+
     suspend fun getById(id: Long): AudioFile?
+
     suspend fun insert(entity: AudioFileEntity): Long
+
     suspend fun delete(id: Long)
-    suspend fun updateDisplayName(id: Long, displayName: String)
-    suspend fun updateLastPlayed(id: Long, positionMs: Long)
-    suspend fun updateLastPosition(id: Long, positionMs: Long)
-    suspend fun updateLastSpeed(id: Long, speed: Float)
+
+    suspend fun updateDisplayName(
+        id: Long,
+        displayName: String,
+    )
+
+    suspend fun updateLastPlayed(
+        id: Long,
+        positionMs: Long,
+    )
+
+    suspend fun updateLastPosition(
+        id: Long,
+        positionMs: Long,
+    )
+
+    suspend fun updateLastSpeed(
+        id: Long,
+        speed: Float,
+    )
 }
 
 @Singleton
-class AudioFileRepositoryImpl @Inject constructor(
-    private val dao: AudioFileDao,
-) : AudioFileRepository {
+class AudioFileRepositoryImpl
+    @Inject
+    constructor(
+        private val dao: AudioFileDao,
+    ) : AudioFileRepository {
+        override fun getAllFiles(): Flow<List<AudioFile>> {
+            return dao.getAll().map { entities -> entities.map { it.toDomain() } }
+        }
 
-    override fun getAllFiles(): Flow<List<AudioFile>> {
-        return dao.getAll().map { entities -> entities.map { it.toDomain() } }
-    }
+        override fun getRecentFiles(limit: Int): Flow<List<AudioFile>> {
+            return dao.getRecent(limit).map { entities -> entities.map { it.toDomain() } }
+        }
 
-    override fun getRecentFiles(limit: Int): Flow<List<AudioFile>> {
-        return dao.getRecent(limit).map { entities -> entities.map { it.toDomain() } }
-    }
+        override suspend fun getById(id: Long): AudioFile? =
+            withContext(Dispatchers.IO) {
+                dao.getById(id)?.toDomain()
+            }
 
-    override suspend fun getById(id: Long): AudioFile? = withContext(Dispatchers.IO) {
-        dao.getById(id)?.toDomain()
-    }
+        override suspend fun insert(entity: AudioFileEntity): Long =
+            withContext(Dispatchers.IO) {
+                dao.insert(entity)
+            }
 
-    override suspend fun insert(entity: AudioFileEntity): Long = withContext(Dispatchers.IO) {
-        dao.insert(entity)
-    }
+        override suspend fun delete(id: Long) =
+            withContext(Dispatchers.IO) {
+                dao.delete(id)
+            }
 
-    override suspend fun delete(id: Long) = withContext(Dispatchers.IO) {
-        dao.delete(id)
-    }
-
-    override suspend fun updateDisplayName(id: Long, displayName: String) =
-        withContext(Dispatchers.IO) {
+        override suspend fun updateDisplayName(
+            id: Long,
+            displayName: String,
+        ) = withContext(Dispatchers.IO) {
             dao.updateDisplayName(id, displayName)
         }
 
-    override suspend fun updateLastPlayed(id: Long, positionMs: Long) =
-        withContext(Dispatchers.IO) {
+        override suspend fun updateLastPlayed(
+            id: Long,
+            positionMs: Long,
+        ) = withContext(Dispatchers.IO) {
             dao.updateLastPlayed(id, System.currentTimeMillis(), positionMs)
         }
 
-    override suspend fun updateLastPosition(id: Long, positionMs: Long) =
-        withContext(Dispatchers.IO) {
+        override suspend fun updateLastPosition(
+            id: Long,
+            positionMs: Long,
+        ) = withContext(Dispatchers.IO) {
             dao.updateLastPosition(id, positionMs)
         }
 
-    override suspend fun updateLastSpeed(id: Long, speed: Float) = withContext(Dispatchers.IO) {
-        dao.updateLastSpeed(id, speed)
+        override suspend fun updateLastSpeed(
+            id: Long,
+            speed: Float,
+        ) = withContext(Dispatchers.IO) {
+            dao.updateLastSpeed(id, speed)
+        }
     }
-}
 
-private fun AudioFileEntity.toDomain(): AudioFile = AudioFile(
-    id = id,
-    displayName = displayName,
-    artist = artist,
-    title = title,
-    format = format,
-    durationMs = durationMs,
-    fileSizeBytes = fileSizeBytes,
-    internalPath = internalPath,
-    importedAt = Instant.ofEpochMilli(importedAt),
-    lastPlayedAt = lastPlayedAt?.let { Instant.ofEpochMilli(it) },
-    lastPositionMs = lastPositionMs,
-    lastSpeed = lastSpeed,
-)
+private fun AudioFileEntity.toDomain(): AudioFile =
+    AudioFile(
+        id = id,
+        displayName = displayName,
+        artist = artist,
+        title = title,
+        format = format,
+        durationMs = durationMs,
+        fileSizeBytes = fileSizeBytes,
+        internalPath = internalPath,
+        importedAt = Instant.ofEpochMilli(importedAt),
+        lastPlayedAt = lastPlayedAt?.let { Instant.ofEpochMilli(it) },
+        lastPositionMs = lastPositionMs,
+        lastSpeed = lastSpeed,
+    )

--- a/app/src/main/java/com/rehearsall/data/repository/BookmarkRepository.kt
+++ b/app/src/main/java/com/rehearsall/data/repository/BookmarkRepository.kt
@@ -13,52 +13,79 @@ import javax.inject.Singleton
 
 interface BookmarkRepository {
     fun getBookmarksForFile(audioFileId: Long): Flow<List<Bookmark>>
-    suspend fun addBookmark(audioFileId: Long, positionMs: Long, name: String): Long
-    suspend fun renameBookmark(id: Long, name: String)
-    suspend fun updateBookmarkPosition(id: Long, positionMs: Long)
+
+    suspend fun addBookmark(
+        audioFileId: Long,
+        positionMs: Long,
+        name: String,
+    ): Long
+
+    suspend fun renameBookmark(
+        id: Long,
+        name: String,
+    )
+
+    suspend fun updateBookmarkPosition(
+        id: Long,
+        positionMs: Long,
+    )
+
     suspend fun deleteBookmark(id: Long)
 }
 
 @Singleton
-class BookmarkRepositoryImpl @Inject constructor(
-    private val dao: BookmarkDao,
-) : BookmarkRepository {
-
-    override fun getBookmarksForFile(audioFileId: Long): Flow<List<Bookmark>> {
-        return dao.getAllForFile(audioFileId).map { entities ->
-            entities.map { it.toDomain() }
+class BookmarkRepositoryImpl
+    @Inject
+    constructor(
+        private val dao: BookmarkDao,
+    ) : BookmarkRepository {
+        override fun getBookmarksForFile(audioFileId: Long): Flow<List<Bookmark>> {
+            return dao.getAllForFile(audioFileId).map { entities ->
+                entities.map { it.toDomain() }
+            }
         }
-    }
 
-    override suspend fun addBookmark(audioFileId: Long, positionMs: Long, name: String): Long =
-        withContext(Dispatchers.IO) {
-            dao.insert(
-                BookmarkEntity(
-                    audioFileId = audioFileId,
-                    positionMs = positionMs,
-                    name = name,
-                    createdAt = System.currentTimeMillis(),
+        override suspend fun addBookmark(
+            audioFileId: Long,
+            positionMs: Long,
+            name: String,
+        ): Long =
+            withContext(Dispatchers.IO) {
+                dao.insert(
+                    BookmarkEntity(
+                        audioFileId = audioFileId,
+                        positionMs = positionMs,
+                        name = name,
+                        createdAt = System.currentTimeMillis(),
+                    ),
                 )
-            )
+            }
+
+        override suspend fun renameBookmark(
+            id: Long,
+            name: String,
+        ) = withContext(Dispatchers.IO) {
+            dao.updateName(id, name)
         }
 
-    override suspend fun renameBookmark(id: Long, name: String) = withContext(Dispatchers.IO) {
-        dao.updateName(id, name)
+        override suspend fun updateBookmarkPosition(
+            id: Long,
+            positionMs: Long,
+        ) = withContext(Dispatchers.IO) {
+            dao.updatePosition(id, positionMs)
+        }
+
+        override suspend fun deleteBookmark(id: Long) =
+            withContext(Dispatchers.IO) {
+                dao.delete(id)
+            }
     }
 
-    override suspend fun updateBookmarkPosition(id: Long, positionMs: Long) = withContext(Dispatchers.IO) {
-        dao.updatePosition(id, positionMs)
-    }
-
-    override suspend fun deleteBookmark(id: Long) = withContext(Dispatchers.IO) {
-        dao.delete(id)
-    }
-}
-
-private fun BookmarkEntity.toDomain(): Bookmark = Bookmark(
-    id = id,
-    audioFileId = audioFileId,
-    positionMs = positionMs,
-    name = name,
-    createdAt = Instant.ofEpochMilli(createdAt),
-)
+private fun BookmarkEntity.toDomain(): Bookmark =
+    Bookmark(
+        id = id,
+        audioFileId = audioFileId,
+        positionMs = positionMs,
+        name = name,
+        createdAt = Instant.ofEpochMilli(createdAt),
+    )

--- a/app/src/main/java/com/rehearsall/data/repository/ChunkMarkerRepository.kt
+++ b/app/src/main/java/com/rehearsall/data/repository/ChunkMarkerRepository.kt
@@ -12,50 +12,77 @@ import javax.inject.Singleton
 
 interface ChunkMarkerRepository {
     fun getMarkersForFile(audioFileId: Long): Flow<List<ChunkMarker>>
-    suspend fun addMarker(audioFileId: Long, positionMs: Long, label: String): Long
-    suspend fun updateLabel(id: Long, label: String)
-    suspend fun updatePosition(id: Long, positionMs: Long)
+
+    suspend fun addMarker(
+        audioFileId: Long,
+        positionMs: Long,
+        label: String,
+    ): Long
+
+    suspend fun updateLabel(
+        id: Long,
+        label: String,
+    )
+
+    suspend fun updatePosition(
+        id: Long,
+        positionMs: Long,
+    )
+
     suspend fun deleteMarker(id: Long)
 }
 
 @Singleton
-class ChunkMarkerRepositoryImpl @Inject constructor(
-    private val dao: ChunkMarkerDao,
-) : ChunkMarkerRepository {
-
-    override fun getMarkersForFile(audioFileId: Long): Flow<List<ChunkMarker>> {
-        return dao.getAllForFile(audioFileId).map { entities ->
-            entities.map { it.toDomain() }
+class ChunkMarkerRepositoryImpl
+    @Inject
+    constructor(
+        private val dao: ChunkMarkerDao,
+    ) : ChunkMarkerRepository {
+        override fun getMarkersForFile(audioFileId: Long): Flow<List<ChunkMarker>> {
+            return dao.getAllForFile(audioFileId).map { entities ->
+                entities.map { it.toDomain() }
+            }
         }
-    }
 
-    override suspend fun addMarker(audioFileId: Long, positionMs: Long, label: String): Long =
-        withContext(Dispatchers.IO) {
-            dao.insert(
-                ChunkMarkerEntity(
-                    audioFileId = audioFileId,
-                    positionMs = positionMs,
-                    label = label,
-                    createdAt = System.currentTimeMillis(),
+        override suspend fun addMarker(
+            audioFileId: Long,
+            positionMs: Long,
+            label: String,
+        ): Long =
+            withContext(Dispatchers.IO) {
+                dao.insert(
+                    ChunkMarkerEntity(
+                        audioFileId = audioFileId,
+                        positionMs = positionMs,
+                        label = label,
+                        createdAt = System.currentTimeMillis(),
+                    ),
                 )
-            )
+            }
+
+        override suspend fun updateLabel(
+            id: Long,
+            label: String,
+        ) = withContext(Dispatchers.IO) {
+            dao.updateLabel(id, label)
         }
 
-    override suspend fun updateLabel(id: Long, label: String) = withContext(Dispatchers.IO) {
-        dao.updateLabel(id, label)
+        override suspend fun updatePosition(
+            id: Long,
+            positionMs: Long,
+        ) = withContext(Dispatchers.IO) {
+            dao.updatePosition(id, positionMs)
+        }
+
+        override suspend fun deleteMarker(id: Long) =
+            withContext(Dispatchers.IO) {
+                dao.delete(id)
+            }
     }
 
-    override suspend fun updatePosition(id: Long, positionMs: Long) = withContext(Dispatchers.IO) {
-        dao.updatePosition(id, positionMs)
-    }
-
-    override suspend fun deleteMarker(id: Long) = withContext(Dispatchers.IO) {
-        dao.delete(id)
-    }
-}
-
-private fun ChunkMarkerEntity.toDomain(): ChunkMarker = ChunkMarker(
-    id = id,
-    positionMs = positionMs,
-    label = label,
-)
+private fun ChunkMarkerEntity.toDomain(): ChunkMarker =
+    ChunkMarker(
+        id = id,
+        positionMs = positionMs,
+        label = label,
+    )

--- a/app/src/main/java/com/rehearsall/data/repository/LoopRepository.kt
+++ b/app/src/main/java/com/rehearsall/data/repository/LoopRepository.kt
@@ -13,54 +13,85 @@ import javax.inject.Singleton
 
 interface LoopRepository {
     fun getLoopsForFile(audioFileId: Long): Flow<List<Loop>>
-    suspend fun saveLoop(audioFileId: Long, name: String, startMs: Long, endMs: Long): Long
-    suspend fun renameLoop(id: Long, name: String)
-    suspend fun updateBounds(id: Long, startMs: Long, endMs: Long)
+
+    suspend fun saveLoop(
+        audioFileId: Long,
+        name: String,
+        startMs: Long,
+        endMs: Long,
+    ): Long
+
+    suspend fun renameLoop(
+        id: Long,
+        name: String,
+    )
+
+    suspend fun updateBounds(
+        id: Long,
+        startMs: Long,
+        endMs: Long,
+    )
+
     suspend fun deleteLoop(id: Long)
 }
 
 @Singleton
-class LoopRepositoryImpl @Inject constructor(
-    private val dao: LoopDao,
-) : LoopRepository {
-
-    override fun getLoopsForFile(audioFileId: Long): Flow<List<Loop>> {
-        return dao.getAllForFile(audioFileId).map { entities ->
-            entities.map { it.toDomain() }
+class LoopRepositoryImpl
+    @Inject
+    constructor(
+        private val dao: LoopDao,
+    ) : LoopRepository {
+        override fun getLoopsForFile(audioFileId: Long): Flow<List<Loop>> {
+            return dao.getAllForFile(audioFileId).map { entities ->
+                entities.map { it.toDomain() }
+            }
         }
-    }
 
-    override suspend fun saveLoop(audioFileId: Long, name: String, startMs: Long, endMs: Long): Long =
-        withContext(Dispatchers.IO) {
-            dao.insert(
-                LoopEntity(
-                    audioFileId = audioFileId,
-                    name = name,
-                    startMs = startMs,
-                    endMs = endMs,
-                    createdAt = System.currentTimeMillis(),
+        override suspend fun saveLoop(
+            audioFileId: Long,
+            name: String,
+            startMs: Long,
+            endMs: Long,
+        ): Long =
+            withContext(Dispatchers.IO) {
+                dao.insert(
+                    LoopEntity(
+                        audioFileId = audioFileId,
+                        name = name,
+                        startMs = startMs,
+                        endMs = endMs,
+                        createdAt = System.currentTimeMillis(),
+                    ),
                 )
-            )
+            }
+
+        override suspend fun renameLoop(
+            id: Long,
+            name: String,
+        ) = withContext(Dispatchers.IO) {
+            dao.updateName(id, name)
         }
 
-    override suspend fun renameLoop(id: Long, name: String) = withContext(Dispatchers.IO) {
-        dao.updateName(id, name)
+        override suspend fun updateBounds(
+            id: Long,
+            startMs: Long,
+            endMs: Long,
+        ) = withContext(Dispatchers.IO) {
+            dao.updateRegion(id, startMs, endMs)
+        }
+
+        override suspend fun deleteLoop(id: Long) =
+            withContext(Dispatchers.IO) {
+                dao.delete(id)
+            }
     }
 
-    override suspend fun updateBounds(id: Long, startMs: Long, endMs: Long) = withContext(Dispatchers.IO) {
-        dao.updateRegion(id, startMs, endMs)
-    }
-
-    override suspend fun deleteLoop(id: Long) = withContext(Dispatchers.IO) {
-        dao.delete(id)
-    }
-}
-
-private fun LoopEntity.toDomain(): Loop = Loop(
-    id = id,
-    audioFileId = audioFileId,
-    name = name,
-    startMs = startMs,
-    endMs = endMs,
-    createdAt = Instant.ofEpochMilli(createdAt),
-)
+private fun LoopEntity.toDomain(): Loop =
+    Loop(
+        id = id,
+        audioFileId = audioFileId,
+        name = name,
+        startMs = startMs,
+        endMs = endMs,
+        createdAt = Instant.ofEpochMilli(createdAt),
+    )

--- a/app/src/main/java/com/rehearsall/data/repository/PlaylistRepository.kt
+++ b/app/src/main/java/com/rehearsall/data/repository/PlaylistRepository.kt
@@ -17,105 +17,143 @@ import javax.inject.Singleton
 
 interface PlaylistRepository {
     fun getAllPlaylists(): Flow<List<Playlist>>
+
     fun getPlaylistItems(playlistId: Long): Flow<List<PlaylistItem>>
+
     suspend fun getById(id: Long): Playlist?
+
     suspend fun createPlaylist(name: String): Long
-    suspend fun renamePlaylist(id: Long, name: String)
+
+    suspend fun renamePlaylist(
+        id: Long,
+        name: String,
+    )
+
     suspend fun deletePlaylist(id: Long)
-    suspend fun addFileToPlaylist(playlistId: Long, audioFileId: Long)
-    suspend fun removeItem(itemId: Long, playlistId: Long)
-    suspend fun reorderItems(playlistId: Long, items: List<Pair<Long, Int>>)
+
+    suspend fun addFileToPlaylist(
+        playlistId: Long,
+        audioFileId: Long,
+    )
+
+    suspend fun removeItem(
+        itemId: Long,
+        playlistId: Long,
+    )
+
+    suspend fun reorderItems(
+        playlistId: Long,
+        items: List<Pair<Long, Int>>,
+    )
 }
 
 @Singleton
-class PlaylistRepositoryImpl @Inject constructor(
-    private val playlistDao: PlaylistDao,
-    private val playlistItemDao: PlaylistItemDao,
-) : PlaylistRepository {
-
-    override fun getAllPlaylists(): Flow<List<Playlist>> {
-        return playlistDao.getAll().map { entities ->
-            entities.map { entity ->
-                val count = playlistItemDao.getItemCount(entity.id)
-                val duration = playlistItemDao.getTotalDuration(entity.id)
-                entity.toDomain(count, duration)
+class PlaylistRepositoryImpl
+    @Inject
+    constructor(
+        private val playlistDao: PlaylistDao,
+        private val playlistItemDao: PlaylistItemDao,
+    ) : PlaylistRepository {
+        override fun getAllPlaylists(): Flow<List<Playlist>> {
+            return playlistDao.getAll().map { entities ->
+                entities.map { entity ->
+                    val count = playlistItemDao.getItemCount(entity.id)
+                    val duration = playlistItemDao.getTotalDuration(entity.id)
+                    entity.toDomain(count, duration)
+                }
             }
         }
-    }
 
-    override fun getPlaylistItems(playlistId: Long): Flow<List<PlaylistItem>> {
-        return playlistItemDao.getItemsWithFiles(playlistId).map { items ->
-            items.map { it.toDomain() }
+        override fun getPlaylistItems(playlistId: Long): Flow<List<PlaylistItem>> {
+            return playlistItemDao.getItemsWithFiles(playlistId).map { items ->
+                items.map { it.toDomain() }
+            }
         }
-    }
 
-    override suspend fun getById(id: Long): Playlist? = withContext(Dispatchers.IO) {
-        val entity = playlistDao.getById(id) ?: return@withContext null
-        val count = playlistItemDao.getItemCount(id)
-        val duration = playlistItemDao.getTotalDuration(id)
-        entity.toDomain(count, duration)
-    }
+        override suspend fun getById(id: Long): Playlist? =
+            withContext(Dispatchers.IO) {
+                val entity = playlistDao.getById(id) ?: return@withContext null
+                val count = playlistItemDao.getItemCount(id)
+                val duration = playlistItemDao.getTotalDuration(id)
+                entity.toDomain(count, duration)
+            }
 
-    override suspend fun createPlaylist(name: String): Long = withContext(Dispatchers.IO) {
-        val now = System.currentTimeMillis()
-        playlistDao.insert(
-            PlaylistEntity(name = name, createdAt = now, updatedAt = now)
-        )
-    }
+        override suspend fun createPlaylist(name: String): Long =
+            withContext(Dispatchers.IO) {
+                val now = System.currentTimeMillis()
+                playlistDao.insert(
+                    PlaylistEntity(name = name, createdAt = now, updatedAt = now),
+                )
+            }
 
-    override suspend fun renamePlaylist(id: Long, name: String) = withContext(Dispatchers.IO) {
-        playlistDao.updateName(id, name)
-    }
+        override suspend fun renamePlaylist(
+            id: Long,
+            name: String,
+        ) = withContext(Dispatchers.IO) {
+            playlistDao.updateName(id, name)
+        }
 
-    override suspend fun deletePlaylist(id: Long) = withContext(Dispatchers.IO) {
-        playlistDao.delete(id) // CASCADE deletes items
-    }
+        override suspend fun deletePlaylist(id: Long) =
+            withContext(Dispatchers.IO) {
+                playlistDao.delete(id) // CASCADE deletes items
+            }
 
-    override suspend fun addFileToPlaylist(playlistId: Long, audioFileId: Long) =
-        withContext(Dispatchers.IO) {
+        override suspend fun addFileToPlaylist(
+            playlistId: Long,
+            audioFileId: Long,
+        ) = withContext(Dispatchers.IO) {
             val maxOrder = playlistItemDao.getMaxOrderIndex(playlistId) ?: -1
             playlistItemDao.insert(
                 PlaylistItemEntity(
                     playlistId = playlistId,
                     audioFileId = audioFileId,
                     orderIndex = maxOrder + 1,
-                )
+                ),
             )
             playlistDao.touch(playlistId)
         }
 
-    override suspend fun removeItem(itemId: Long, playlistId: Long) =
-        withContext(Dispatchers.IO) {
+        override suspend fun removeItem(
+            itemId: Long,
+            playlistId: Long,
+        ) = withContext(Dispatchers.IO) {
             playlistItemDao.delete(itemId)
             playlistDao.touch(playlistId)
         }
 
-    override suspend fun reorderItems(playlistId: Long, items: List<Pair<Long, Int>>) =
-        withContext(Dispatchers.IO) {
+        override suspend fun reorderItems(
+            playlistId: Long,
+            items: List<Pair<Long, Int>>,
+        ) = withContext(Dispatchers.IO) {
             items.forEach { (id, order) ->
                 playlistItemDao.updateOrder(id, order)
             }
             playlistDao.touch(playlistId)
         }
-}
+    }
 
-private fun PlaylistEntity.toDomain(trackCount: Int, totalDurationMs: Long): Playlist = Playlist(
-    id = id,
-    name = name,
-    trackCount = trackCount,
-    totalDurationMs = totalDurationMs,
-    createdAt = Instant.ofEpochMilli(createdAt),
-    updatedAt = Instant.ofEpochMilli(updatedAt),
-)
+private fun PlaylistEntity.toDomain(
+    trackCount: Int,
+    totalDurationMs: Long,
+): Playlist =
+    Playlist(
+        id = id,
+        name = name,
+        trackCount = trackCount,
+        totalDurationMs = totalDurationMs,
+        createdAt = Instant.ofEpochMilli(createdAt),
+        updatedAt = Instant.ofEpochMilli(updatedAt),
+    )
 
-private fun PlaylistItemWithFile.toDomain(): PlaylistItem = PlaylistItem(
-    id = id,
-    playlistId = playlistId,
-    audioFileId = audioFileId,
-    orderIndex = orderIndex,
-    displayName = displayName,
-    artist = artist,
-    durationMs = durationMs,
-    internalPath = internalPath,
-    format = format,
-)
+private fun PlaylistItemWithFile.toDomain(): PlaylistItem =
+    PlaylistItem(
+        id = id,
+        playlistId = playlistId,
+        audioFileId = audioFileId,
+        orderIndex = orderIndex,
+        displayName = displayName,
+        artist = artist,
+        durationMs = durationMs,
+        internalPath = internalPath,
+        format = format,
+    )

--- a/app/src/main/java/com/rehearsall/data/repository/PracticeSettingsRepository.kt
+++ b/app/src/main/java/com/rehearsall/data/repository/PracticeSettingsRepository.kt
@@ -11,21 +11,28 @@ import javax.inject.Singleton
 
 interface PracticeSettingsRepository {
     suspend fun getForFile(audioFileId: Long): PracticeSettings
-    suspend fun save(audioFileId: Long, settings: PracticeSettings)
+
+    suspend fun save(
+        audioFileId: Long,
+        settings: PracticeSettings,
+    )
 }
 
 @Singleton
-class PracticeSettingsRepositoryImpl @Inject constructor(
-    private val dao: PracticeSettingsDao,
-) : PracticeSettingsRepository {
+class PracticeSettingsRepositoryImpl
+    @Inject
+    constructor(
+        private val dao: PracticeSettingsDao,
+    ) : PracticeSettingsRepository {
+        override suspend fun getForFile(audioFileId: Long): PracticeSettings =
+            withContext(Dispatchers.IO) {
+                dao.getForFile(audioFileId)?.toDomain() ?: PracticeSettings()
+            }
 
-    override suspend fun getForFile(audioFileId: Long): PracticeSettings =
-        withContext(Dispatchers.IO) {
-            dao.getForFile(audioFileId)?.toDomain() ?: PracticeSettings()
-        }
-
-    override suspend fun save(audioFileId: Long, settings: PracticeSettings) =
-        withContext(Dispatchers.IO) {
+        override suspend fun save(
+            audioFileId: Long,
+            settings: PracticeSettings,
+        ) = withContext(Dispatchers.IO) {
             dao.insertOrUpdate(
                 PracticeSettingsEntity(
                     audioFileId = audioFileId,
@@ -33,18 +40,20 @@ class PracticeSettingsRepositoryImpl @Inject constructor(
                     gapBetweenRepsMs = settings.gapBetweenRepsMs,
                     gapBetweenChunksMs = settings.gapBetweenChunksMs,
                     selectedMode = settings.mode.name,
-                )
+                ),
             )
         }
-}
+    }
 
-private fun PracticeSettingsEntity.toDomain(): PracticeSettings = PracticeSettings(
-    repeatCount = repeatCount,
-    gapBetweenRepsMs = gapBetweenRepsMs,
-    gapBetweenChunksMs = gapBetweenChunksMs,
-    mode = try {
-        PracticeMode.valueOf(selectedMode)
-    } catch (_: IllegalArgumentException) {
-        PracticeMode.SINGLE_CHUNK_LOOP
-    },
-)
+private fun PracticeSettingsEntity.toDomain(): PracticeSettings =
+    PracticeSettings(
+        repeatCount = repeatCount,
+        gapBetweenRepsMs = gapBetweenRepsMs,
+        gapBetweenChunksMs = gapBetweenChunksMs,
+        mode =
+            try {
+                PracticeMode.valueOf(selectedMode)
+            } catch (_: IllegalArgumentException) {
+                PracticeMode.SINGLE_CHUNK_LOOP
+            },
+    )

--- a/app/src/main/java/com/rehearsall/data/repository/WaveformRepository.kt
+++ b/app/src/main/java/com/rehearsall/data/repository/WaveformRepository.kt
@@ -10,57 +10,68 @@ import javax.inject.Singleton
 
 sealed interface WaveformState {
     data object Loading : WaveformState
+
     data class Ready(val amplitudes: FloatArray) : WaveformState {
-        override fun equals(other: Any?): Boolean =
-            other is Ready && amplitudes.contentEquals(other.amplitudes)
+        override fun equals(other: Any?): Boolean = other is Ready && amplitudes.contentEquals(other.amplitudes)
+
         override fun hashCode(): Int = amplitudes.contentHashCode()
     }
+
     data class Error(val message: String) : WaveformState
 }
 
 @Singleton
-class WaveformRepository @Inject constructor(
-    private val extractor: WaveformExtractor,
-    private val cache: WaveformCache,
-) {
-    /**
-     * Returns a Flow that emits Loading, then Ready (from cache or extraction).
-     * Cache-first: if cached, skips extraction entirely.
-     */
-    fun getWaveform(audioFileId: Long, filePath: String): Flow<WaveformState> = flow {
-        emit(WaveformState.Loading)
+class WaveformRepository
+    @Inject
+    constructor(
+        private val extractor: WaveformExtractor,
+        private val cache: WaveformCache,
+    ) {
+        /**
+         * Returns a Flow that emits Loading, then Ready (from cache or extraction).
+         * Cache-first: if cached, skips extraction entirely.
+         */
+        fun getWaveform(
+            audioFileId: Long,
+            filePath: String,
+        ): Flow<WaveformState> =
+            flow {
+                emit(WaveformState.Loading)
 
-        // Try cache first
-        val cached = cache.load(audioFileId)
-        if (cached != null) {
-            emit(WaveformState.Ready(cached))
-            return@flow
-        }
+                // Try cache first
+                val cached = cache.load(audioFileId)
+                if (cached != null) {
+                    emit(WaveformState.Ready(cached))
+                    return@flow
+                }
 
-        // Extract from file
-        val result = extractor.extract(filePath)
-        result.fold(
-            onSuccess = { amplitudes ->
+                // Extract from file
+                val result = extractor.extract(filePath)
+                result.fold(
+                    onSuccess = { amplitudes ->
+                        cache.save(audioFileId, amplitudes)
+                        emit(WaveformState.Ready(amplitudes))
+                    },
+                    onFailure = { error ->
+                        Timber.e(error, "Waveform extraction failed for id=%d", audioFileId)
+                        emit(WaveformState.Error(error.message ?: "Extraction failed"))
+                    },
+                )
+            }
+
+        /**
+         * Extract and cache waveform in the background (e.g., after import).
+         * Does nothing if already cached.
+         */
+        suspend fun ensureCached(
+            audioFileId: Long,
+            filePath: String,
+        ) {
+            if (cache.isCached(audioFileId)) return
+
+            val result = extractor.extract(filePath)
+            result.onSuccess { amplitudes ->
                 cache.save(audioFileId, amplitudes)
-                emit(WaveformState.Ready(amplitudes))
-            },
-            onFailure = { error ->
-                Timber.e(error, "Waveform extraction failed for id=%d", audioFileId)
-                emit(WaveformState.Error(error.message ?: "Extraction failed"))
-            },
-        )
-    }
-
-    /**
-     * Extract and cache waveform in the background (e.g., after import).
-     * Does nothing if already cached.
-     */
-    suspend fun ensureCached(audioFileId: Long, filePath: String) {
-        if (cache.isCached(audioFileId)) return
-
-        val result = extractor.extract(filePath)
-        result.onSuccess { amplitudes ->
-            cache.save(audioFileId, amplitudes)
+            }
         }
     }
-}

--- a/app/src/main/java/com/rehearsall/di/AudioModule.kt
+++ b/app/src/main/java/com/rehearsall/di/AudioModule.kt
@@ -11,7 +11,6 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 abstract class AudioModule {
-
     @Binds
     @Singleton
     abstract fun bindPlaybackManager(impl: PlaybackManagerImpl): PlaybackManager

--- a/app/src/main/java/com/rehearsall/di/DatabaseModule.kt
+++ b/app/src/main/java/com/rehearsall/di/DatabaseModule.kt
@@ -8,8 +8,8 @@ import com.rehearsall.data.db.dao.BookmarkDao
 import com.rehearsall.data.db.dao.ChunkMarkerDao
 import com.rehearsall.data.db.dao.LoopDao
 import com.rehearsall.data.db.dao.PlaylistDao
-import com.rehearsall.data.db.dao.PracticeSettingsDao
 import com.rehearsall.data.db.dao.PlaylistItemDao
+import com.rehearsall.data.db.dao.PracticeSettingsDao
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -20,10 +20,11 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object DatabaseModule {
-
     @Provides
     @Singleton
-    fun provideDatabase(@ApplicationContext context: Context): RehearsAllDatabase {
+    fun provideDatabase(
+        @ApplicationContext context: Context,
+    ): RehearsAllDatabase {
         return Room.databaseBuilder(
             context,
             RehearsAllDatabase::class.java,

--- a/app/src/main/java/com/rehearsall/di/PreferencesModule.kt
+++ b/app/src/main/java/com/rehearsall/di/PreferencesModule.kt
@@ -19,10 +19,11 @@ private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(na
 @Module
 @InstallIn(SingletonComponent::class)
 object PreferencesModule {
-
     @Provides
     @Singleton
-    fun provideDataStore(@ApplicationContext context: Context): DataStore<Preferences> {
+    fun provideDataStore(
+        @ApplicationContext context: Context,
+    ): DataStore<Preferences> {
         return context.dataStore
     }
 }

--- a/app/src/main/java/com/rehearsall/di/RepositoryModule.kt
+++ b/app/src/main/java/com/rehearsall/di/RepositoryModule.kt
@@ -8,10 +8,10 @@ import com.rehearsall.data.repository.ChunkMarkerRepository
 import com.rehearsall.data.repository.ChunkMarkerRepositoryImpl
 import com.rehearsall.data.repository.LoopRepository
 import com.rehearsall.data.repository.LoopRepositoryImpl
-import com.rehearsall.data.repository.PracticeSettingsRepository
-import com.rehearsall.data.repository.PracticeSettingsRepositoryImpl
 import com.rehearsall.data.repository.PlaylistRepository
 import com.rehearsall.data.repository.PlaylistRepositoryImpl
+import com.rehearsall.data.repository.PracticeSettingsRepository
+import com.rehearsall.data.repository.PracticeSettingsRepositoryImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -21,7 +21,6 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 abstract class RepositoryModule {
-
     @Binds
     @Singleton
     abstract fun bindAudioFileRepository(impl: AudioFileRepositoryImpl): AudioFileRepository

--- a/app/src/main/java/com/rehearsall/di/ServiceEntryPoint.kt
+++ b/app/src/main/java/com/rehearsall/di/ServiceEntryPoint.kt
@@ -17,8 +17,12 @@ import dagger.hilt.components.SingletonComponent
 @InstallIn(SingletonComponent::class)
 interface ServiceEntryPoint {
     fun audioFileDao(): AudioFileDao
+
     fun playlistDao(): PlaylistDao
+
     fun playlistItemDao(): PlaylistItemDao
+
     fun loopDao(): LoopDao
+
     fun userPreferencesRepository(): UserPreferencesRepository
 }

--- a/app/src/main/java/com/rehearsall/domain/usecase/GeneratePracticeStepsUseCase.kt
+++ b/app/src/main/java/com/rehearsall/domain/usecase/GeneratePracticeStepsUseCase.kt
@@ -12,7 +12,6 @@ import com.rehearsall.domain.model.PracticeStep
  *   (0..marker1), (marker1..marker2), ..., (markerN..duration)
  */
 object GeneratePracticeStepsUseCase {
-
     /**
      * Derives chunk boundaries from markers.
      * Returns list of (startMs, endMs, label) triples sorted by position.
@@ -36,7 +35,7 @@ object GeneratePracticeStepsUseCase {
                     sorted[i].positionMs,
                     sorted[i + 1].positionMs,
                     "Chunk ${i + 2}",
-                )
+                ),
             )
         }
 
@@ -93,7 +92,7 @@ object GeneratePracticeStepsUseCase {
                 label = first.third,
                 repeatCount = repeatCount,
                 chunkRange = first.third,
-            )
+            ),
         )
 
         // For each subsequent chunk: solo, then cumulative from start
@@ -108,7 +107,7 @@ object GeneratePracticeStepsUseCase {
                     label = "${current.third} (solo)",
                     repeatCount = repeatCount,
                     chunkRange = current.third,
-                )
+                ),
             )
 
             // Cumulative: chunk 1 through current
@@ -119,7 +118,7 @@ object GeneratePracticeStepsUseCase {
                     label = "Chunks 1–${i + 1}",
                     repeatCount = repeatCount,
                     chunkRange = "1–${i + 1}",
-                )
+                ),
             )
         }
 

--- a/app/src/main/java/com/rehearsall/logging/FileLoggingTree.kt
+++ b/app/src/main/java/com/rehearsall/logging/FileLoggingTree.kt
@@ -17,7 +17,6 @@ import java.util.Locale
  * when the file exceeds 5MB, it's truncated to the most recent half.
  */
 class FileLoggingTree(filesDir: File) : Timber.Tree() {
-
     private val logFile: File
     private val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
     private val maxFileSize = 5L * 1024 * 1024 // 5MB
@@ -28,22 +27,31 @@ class FileLoggingTree(filesDir: File) : Timber.Tree() {
         logFile = File(logDir, "rehearsall.log")
     }
 
-    override fun isLoggable(tag: String?, priority: Int): Boolean {
+    override fun isLoggable(
+        tag: String?,
+        priority: Int,
+    ): Boolean {
         // Only log warnings and above in release builds
         return priority >= Log.WARN
     }
 
-    override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+    override fun log(
+        priority: Int,
+        tag: String?,
+        message: String,
+        t: Throwable?,
+    ) {
         try {
             rotateIfNeeded()
 
             val timestamp = dateFormat.format(Date())
-            val level = when (priority) {
-                Log.WARN -> "W"
-                Log.ERROR -> "E"
-                Log.ASSERT -> "A"
-                else -> "I"
-            }
+            val level =
+                when (priority) {
+                    Log.WARN -> "W"
+                    Log.ERROR -> "E"
+                    Log.ASSERT -> "A"
+                    else -> "I"
+                }
 
             FileWriter(logFile, true).use { writer ->
                 writer.appendLine("$timestamp $level/$tag: $message")

--- a/app/src/main/java/com/rehearsall/playback/ChunkedPracticeEngine.kt
+++ b/app/src/main/java/com/rehearsall/playback/ChunkedPracticeEngine.kt
@@ -18,158 +18,167 @@ import javax.inject.Singleton
  * counts reps via loop region enforcement, and pauses between reps/chunks.
  */
 @Singleton
-class ChunkedPracticeEngine @Inject constructor(
-    private val playbackManager: PlaybackManager,
-) {
-    private val _state = MutableStateFlow<PracticeState>(PracticeState.Idle)
-    val state: StateFlow<PracticeState> = _state.asStateFlow()
-
-    private var practiceJob: Job? = null
-    private var steps: List<PracticeStep> = emptyList()
-    private var settings: PracticeSettings = PracticeSettings()
-    private var currentStepIndex = 0
-
-    fun startPractice(
-        steps: List<PracticeStep>,
-        settings: PracticeSettings,
-        scope: CoroutineScope,
+class ChunkedPracticeEngine
+    @Inject
+    constructor(
+        private val playbackManager: PlaybackManager,
     ) {
-        if (steps.isEmpty()) return
-        stopPractice()
+        private val _state = MutableStateFlow<PracticeState>(PracticeState.Idle)
+        val state: StateFlow<PracticeState> = _state.asStateFlow()
 
-        this.steps = steps
-        this.settings = settings
-        this.currentStepIndex = 0
+        private var practiceJob: Job? = null
+        private var steps: List<PracticeStep> = emptyList()
+        private var settings: PracticeSettings = PracticeSettings()
+        private var currentStepIndex = 0
 
-        practiceJob = scope.launch {
-            runPractice()
+        fun startPractice(
+            steps: List<PracticeStep>,
+            settings: PracticeSettings,
+            scope: CoroutineScope,
+        ) {
+            if (steps.isEmpty()) return
+            stopPractice()
+
+            this.steps = steps
+            this.settings = settings
+            this.currentStepIndex = 0
+
+            practiceJob =
+                scope.launch {
+                    runPractice()
+                }
         }
-    }
 
-    private suspend fun runPractice() {
-        for (i in steps.indices) {
-            currentStepIndex = i
-            val step = steps[i]
+        private suspend fun runPractice() {
+            for (i in steps.indices) {
+                currentStepIndex = i
+                val step = steps[i]
 
-            for (rep in 1..step.repeatCount) {
-                _state.value = PracticeState.Playing(
-                    currentStep = step,
-                    stepIndex = i,
-                    totalSteps = steps.size,
-                    currentRep = rep,
-                    totalReps = step.repeatCount,
-                )
+                for (rep in 1..step.repeatCount) {
+                    _state.value =
+                        PracticeState.Playing(
+                            currentStep = step,
+                            stepIndex = i,
+                            totalSteps = steps.size,
+                            currentRep = rep,
+                            totalReps = step.repeatCount,
+                        )
 
-                // Set loop region and seek to start
-                playbackManager.setLoopRegion(LoopRegion(step.startMs, step.endMs))
-                playbackManager.seekTo(step.startMs)
-                playbackManager.play()
+                    // Set loop region and seek to start
+                    playbackManager.setLoopRegion(LoopRegion(step.startMs, step.endMs))
+                    playbackManager.seekTo(step.startMs)
+                    playbackManager.play()
 
-                // Wait for this rep to complete (duration of the chunk)
-                val chunkDuration = step.endMs - step.startMs
-                val adjustedDuration = (chunkDuration / playbackManager.playbackState.value.speed.coerceAtLeast(0.25f)).toLong()
-                delay(adjustedDuration)
+                    // Wait for this rep to complete (duration of the chunk)
+                    val chunkDuration = step.endMs - step.startMs
+                    val adjustedDuration = (chunkDuration / playbackManager.playbackState.value.speed.coerceAtLeast(0.25f)).toLong()
+                    delay(adjustedDuration)
 
-                // Gap between reps (except after last rep)
-                if (rep < step.repeatCount && settings.gapBetweenRepsMs > 0) {
+                    // Gap between reps (except after last rep)
+                    if (rep < step.repeatCount && settings.gapBetweenRepsMs > 0) {
+                        playbackManager.pause()
+                        delay(settings.gapBetweenRepsMs)
+                    }
+                }
+
+                // Gap between chunks (except after last chunk)
+                if (i < steps.size - 1 && settings.gapBetweenChunksMs > 0) {
                     playbackManager.pause()
-                    delay(settings.gapBetweenRepsMs)
+                    _state.value =
+                        PracticeState.Pausing(
+                            nextStep = steps.getOrNull(i + 1),
+                            stepIndex = i,
+                            totalSteps = steps.size,
+                        )
+                    delay(settings.gapBetweenChunksMs)
                 }
             }
 
-            // Gap between chunks (except after last chunk)
-            if (i < steps.size - 1 && settings.gapBetweenChunksMs > 0) {
-                playbackManager.pause()
-                _state.value = PracticeState.Pausing(
-                    nextStep = steps.getOrNull(i + 1),
-                    stepIndex = i,
-                    totalSteps = steps.size,
-                )
-                delay(settings.gapBetweenChunksMs)
-            }
-        }
-
-        // Practice complete
-        playbackManager.pause()
-        playbackManager.clearLoopRegion()
-        _state.value = PracticeState.Complete
-        Timber.i("Practice session complete: %d steps", steps.size)
-    }
-
-    fun skipToNextStep() {
-        val nextIndex = currentStepIndex + 1
-        if (nextIndex < steps.size) {
-            practiceJob?.cancel()
-            currentStepIndex = nextIndex
-            practiceJob = kotlinx.coroutines.CoroutineScope(
-                kotlinx.coroutines.Dispatchers.Main + kotlinx.coroutines.SupervisorJob()
-            ).launch {
-                runFromStep(nextIndex)
-            }
-        }
-    }
-
-    fun skipToPreviousStep() {
-        val prevIndex = (currentStepIndex - 1).coerceAtLeast(0)
-        practiceJob?.cancel()
-        currentStepIndex = prevIndex
-        practiceJob = kotlinx.coroutines.CoroutineScope(
-            kotlinx.coroutines.Dispatchers.Main + kotlinx.coroutines.SupervisorJob()
-        ).launch {
-            runFromStep(prevIndex)
-        }
-    }
-
-    private suspend fun runFromStep(startIndex: Int) {
-        for (i in startIndex until steps.size) {
-            currentStepIndex = i
-            val step = steps[i]
-
-            for (rep in 1..step.repeatCount) {
-                _state.value = PracticeState.Playing(
-                    currentStep = step,
-                    stepIndex = i,
-                    totalSteps = steps.size,
-                    currentRep = rep,
-                    totalReps = step.repeatCount,
-                )
-
-                playbackManager.setLoopRegion(LoopRegion(step.startMs, step.endMs))
-                playbackManager.seekTo(step.startMs)
-                playbackManager.play()
-
-                val chunkDuration = step.endMs - step.startMs
-                val adjustedDuration = (chunkDuration / playbackManager.playbackState.value.speed.coerceAtLeast(0.25f)).toLong()
-                delay(adjustedDuration)
-
-                if (rep < step.repeatCount && settings.gapBetweenRepsMs > 0) {
-                    playbackManager.pause()
-                    delay(settings.gapBetweenRepsMs)
-                }
-            }
-
-            if (i < steps.size - 1 && settings.gapBetweenChunksMs > 0) {
-                playbackManager.pause()
-                _state.value = PracticeState.Pausing(
-                    nextStep = steps.getOrNull(i + 1),
-                    stepIndex = i,
-                    totalSteps = steps.size,
-                )
-                delay(settings.gapBetweenChunksMs)
-            }
-        }
-
-        playbackManager.pause()
-        playbackManager.clearLoopRegion()
-        _state.value = PracticeState.Complete
-    }
-
-    fun stopPractice() {
-        practiceJob?.cancel()
-        practiceJob = null
-        if (_state.value !is PracticeState.Idle) {
+            // Practice complete
+            playbackManager.pause()
             playbackManager.clearLoopRegion()
-            _state.value = PracticeState.Idle
+            _state.value = PracticeState.Complete
+            Timber.i("Practice session complete: %d steps", steps.size)
+        }
+
+        fun skipToNextStep() {
+            val nextIndex = currentStepIndex + 1
+            if (nextIndex < steps.size) {
+                practiceJob?.cancel()
+                currentStepIndex = nextIndex
+                practiceJob =
+                    kotlinx.coroutines.CoroutineScope(
+                        kotlinx.coroutines.Dispatchers.Main + kotlinx.coroutines.SupervisorJob(),
+                    ).launch {
+                        runFromStep(nextIndex)
+                    }
+            }
+        }
+
+        fun skipToPreviousStep() {
+            val prevIndex = (currentStepIndex - 1).coerceAtLeast(0)
+            practiceJob?.cancel()
+            currentStepIndex = prevIndex
+            practiceJob =
+                kotlinx.coroutines.CoroutineScope(
+                    kotlinx.coroutines.Dispatchers.Main + kotlinx.coroutines.SupervisorJob(),
+                ).launch {
+                    runFromStep(prevIndex)
+                }
+        }
+
+        private suspend fun runFromStep(startIndex: Int) {
+            for (i in startIndex until steps.size) {
+                currentStepIndex = i
+                val step = steps[i]
+
+                for (rep in 1..step.repeatCount) {
+                    _state.value =
+                        PracticeState.Playing(
+                            currentStep = step,
+                            stepIndex = i,
+                            totalSteps = steps.size,
+                            currentRep = rep,
+                            totalReps = step.repeatCount,
+                        )
+
+                    playbackManager.setLoopRegion(LoopRegion(step.startMs, step.endMs))
+                    playbackManager.seekTo(step.startMs)
+                    playbackManager.play()
+
+                    val chunkDuration = step.endMs - step.startMs
+                    val adjustedDuration = (chunkDuration / playbackManager.playbackState.value.speed.coerceAtLeast(0.25f)).toLong()
+                    delay(adjustedDuration)
+
+                    if (rep < step.repeatCount && settings.gapBetweenRepsMs > 0) {
+                        playbackManager.pause()
+                        delay(settings.gapBetweenRepsMs)
+                    }
+                }
+
+                if (i < steps.size - 1 && settings.gapBetweenChunksMs > 0) {
+                    playbackManager.pause()
+                    _state.value =
+                        PracticeState.Pausing(
+                            nextStep = steps.getOrNull(i + 1),
+                            stepIndex = i,
+                            totalSteps = steps.size,
+                        )
+                    delay(settings.gapBetweenChunksMs)
+                }
+            }
+
+            playbackManager.pause()
+            playbackManager.clearLoopRegion()
+            _state.value = PracticeState.Complete
+        }
+
+        fun stopPractice() {
+            practiceJob?.cancel()
+            practiceJob = null
+            if (_state.value !is PracticeState.Idle) {
+                playbackManager.clearLoopRegion()
+                _state.value = PracticeState.Idle
+            }
         }
     }
-}

--- a/app/src/main/java/com/rehearsall/playback/ContentTreeBuilder.kt
+++ b/app/src/main/java/com/rehearsall/playback/ContentTreeBuilder.kt
@@ -23,7 +23,6 @@ class ContentTreeBuilder(
     private val playlistItemDao: PlaylistItemDao,
     private val loopDao: LoopDao,
 ) {
-
     companion object {
         const val ROOT_ID = "root"
         const val RECENT_ID = "recent"

--- a/app/src/main/java/com/rehearsall/playback/LoopActionHandler.kt
+++ b/app/src/main/java/com/rehearsall/playback/LoopActionHandler.kt
@@ -1,8 +1,6 @@
 package com.rehearsall.playback
 
-import android.os.Bundle
 import androidx.media3.common.MediaItem
-import androidx.media3.session.SessionCommand
 import com.rehearsall.data.db.dao.LoopDao
 import timber.log.Timber
 
@@ -59,6 +57,8 @@ class LoopActionHandler(
 
         return if (startMs >= 0 && endMs > startMs) {
             LoopRegion(startMs, endMs)
-        } else null
+        } else {
+            null
+        }
     }
 }

--- a/app/src/main/java/com/rehearsall/playback/MediaItemMapper.kt
+++ b/app/src/main/java/com/rehearsall/playback/MediaItemMapper.kt
@@ -12,8 +12,10 @@ import com.rehearsall.data.db.entity.PlaylistEntity
  * Browsable items let the user navigate deeper; playable items start playback.
  */
 object MediaItemMapper {
-
-    fun browsableFolder(mediaId: String, title: String): MediaItem {
+    fun browsableFolder(
+        mediaId: String,
+        title: String,
+    ): MediaItem {
         return MediaItem.Builder()
             .setMediaId(mediaId)
             .setMediaMetadata(
@@ -22,7 +24,7 @@ object MediaItemMapper {
                     .setIsBrowsable(true)
                     .setIsPlayable(false)
                     .setMediaType(MediaMetadata.MEDIA_TYPE_FOLDER_MIXED)
-                    .build()
+                    .build(),
             )
             .build()
     }
@@ -38,11 +40,13 @@ object MediaItemMapper {
                     .setIsBrowsable(false)
                     .setIsPlayable(true)
                     .setMediaType(MediaMetadata.MEDIA_TYPE_MUSIC)
-                    .setExtras(Bundle().apply {
-                        putLong("fileId", file.id)
-                        putLong("durationMs", file.durationMs)
-                    })
-                    .build()
+                    .setExtras(
+                        Bundle().apply {
+                            putLong("fileId", file.id)
+                            putLong("durationMs", file.durationMs)
+                        },
+                    )
+                    .build(),
             )
             .build()
     }
@@ -57,10 +61,12 @@ object MediaItemMapper {
                     .setIsBrowsable(true)
                     .setIsPlayable(false)
                     .setMediaType(MediaMetadata.MEDIA_TYPE_FOLDER_MIXED)
-                    .setExtras(Bundle().apply {
-                        putLong("fileId", file.id)
-                    })
-                    .build()
+                    .setExtras(
+                        Bundle().apply {
+                            putLong("fileId", file.id)
+                        },
+                    )
+                    .build(),
             )
             .build()
     }
@@ -76,15 +82,20 @@ object MediaItemMapper {
                     .setIsBrowsable(false)
                     .setIsPlayable(true)
                     .setMediaType(MediaMetadata.MEDIA_TYPE_MUSIC)
-                    .setExtras(Bundle().apply {
-                        putLong("fileId", file.id)
-                    })
-                    .build()
+                    .setExtras(
+                        Bundle().apply {
+                            putLong("fileId", file.id)
+                        },
+                    )
+                    .build(),
             )
             .build()
     }
 
-    fun loopItem(file: AudioFileEntity, loop: LoopEntity): MediaItem {
+    fun loopItem(
+        file: AudioFileEntity,
+        loop: LoopEntity,
+    ): MediaItem {
         val durationSec = (loop.endMs - loop.startMs) / 1000
         return MediaItem.Builder()
             .setMediaId("file:${file.id}:loop:${loop.id}")
@@ -96,13 +107,15 @@ object MediaItemMapper {
                     .setIsBrowsable(false)
                     .setIsPlayable(true)
                     .setMediaType(MediaMetadata.MEDIA_TYPE_MUSIC)
-                    .setExtras(Bundle().apply {
-                        putLong("fileId", file.id)
-                        putLong("loopId", loop.id)
-                        putLong("loopStartMs", loop.startMs)
-                        putLong("loopEndMs", loop.endMs)
-                    })
-                    .build()
+                    .setExtras(
+                        Bundle().apply {
+                            putLong("fileId", file.id)
+                            putLong("loopId", loop.id)
+                            putLong("loopStartMs", loop.startMs)
+                            putLong("loopEndMs", loop.endMs)
+                        },
+                    )
+                    .build(),
             )
             .build()
     }
@@ -116,14 +129,17 @@ object MediaItemMapper {
                     .setIsBrowsable(true)
                     .setIsPlayable(false)
                     .setMediaType(MediaMetadata.MEDIA_TYPE_PLAYLIST)
-                    .build()
+                    .build(),
             )
             .build()
     }
 
-    fun playlistTrackItem(file: AudioFileEntity, playlistId: Long): MediaItem {
+    fun playlistTrackItem(
+        file: AudioFileEntity,
+        playlistId: Long,
+    ): MediaItem {
         return MediaItem.Builder()
-            .setMediaId("playlist:${playlistId}:file:${file.id}")
+            .setMediaId("playlist:$playlistId:file:${file.id}")
             .setUri(file.internalPath)
             .setMediaMetadata(
                 MediaMetadata.Builder()
@@ -132,10 +148,12 @@ object MediaItemMapper {
                     .setIsBrowsable(false)
                     .setIsPlayable(true)
                     .setMediaType(MediaMetadata.MEDIA_TYPE_MUSIC)
-                    .setExtras(Bundle().apply {
-                        putLong("fileId", file.id)
-                    })
-                    .build()
+                    .setExtras(
+                        Bundle().apply {
+                            putLong("fileId", file.id)
+                        },
+                    )
+                    .build(),
             )
             .build()
     }

--- a/app/src/main/java/com/rehearsall/playback/PlaybackManager.kt
+++ b/app/src/main/java/com/rehearsall/playback/PlaybackManager.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.flow.StateFlow
  * Wraps MediaController commands under the hood.
  */
 interface PlaybackManager {
-
     // -- State observation --
     val playbackState: StateFlow<PlaybackState>
     val currentFileId: StateFlow<Long?>
@@ -17,11 +16,17 @@ interface PlaybackManager {
 
     // -- Transport --
     fun play()
+
     fun pause()
+
     fun seekTo(positionMs: Long)
+
     fun skipForward(ms: Long)
+
     fun skipBackward(ms: Long)
+
     fun skipToNext()
+
     fun skipToPrevious()
 
     // -- Speed (0.25x – 3.0x, pitch-preserved) --
@@ -29,18 +34,38 @@ interface PlaybackManager {
 
     // -- Queue --
     val currentQueue: StateFlow<List<QueueItem>>
-    fun playFile(fileId: Long, path: String, startPositionMs: Long = 0L)
-    fun setQueue(items: List<QueueItem>, startIndex: Int = 0)
+
+    fun playFile(
+        fileId: Long,
+        path: String,
+        startPositionMs: Long = 0L,
+    )
+
+    fun setQueue(
+        items: List<QueueItem>,
+        startIndex: Int = 0,
+    )
+
     fun skipToQueueItem(index: Int)
+
     fun removeFromQueue(index: Int)
-    fun moveQueueItem(fromIndex: Int, toIndex: Int)
+
+    fun moveQueueItem(
+        fromIndex: Int,
+        toIndex: Int,
+    )
+
     fun clearQueue()
+
     fun setRepeatMode(mode: RepeatMode)
+
     fun setShuffleEnabled(enabled: Boolean)
 
     // -- A-B loop --
     val loopRegion: StateFlow<LoopRegion?>
+
     fun setLoopRegion(region: LoopRegion)
+
     fun clearLoopRegion()
 
     // -- Lifecycle --

--- a/app/src/main/java/com/rehearsall/playback/PlaybackManagerImpl.kt
+++ b/app/src/main/java/com/rehearsall/playback/PlaybackManagerImpl.kt
@@ -33,337 +33,365 @@ import javax.inject.Singleton
  * and polls position at ~60 fps while playing to keep the UI scrubber smooth.
  */
 @Singleton
-class PlaybackManagerImpl @Inject constructor(
-    @ApplicationContext private val context: Context,
-) : PlaybackManager {
+class PlaybackManagerImpl
+    @Inject
+    constructor(
+        @ApplicationContext private val context: Context,
+    ) : PlaybackManager {
+        private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+        private var browser: MediaBrowser? = null
+        private var isConnecting = false
 
-    private var browser: MediaBrowser? = null
-    private var isConnecting = false
+        // -- Exposed state flows --
+        private val _playbackState = MutableStateFlow(PlaybackState.IDLE)
+        override val playbackState: StateFlow<PlaybackState> = _playbackState.asStateFlow()
 
-    // -- Exposed state flows --
-    private val _playbackState = MutableStateFlow(PlaybackState.IDLE)
-    override val playbackState: StateFlow<PlaybackState> = _playbackState.asStateFlow()
+        private val _currentFileId = MutableStateFlow<Long?>(null)
+        override val currentFileId: StateFlow<Long?> = _currentFileId.asStateFlow()
 
-    private val _currentFileId = MutableStateFlow<Long?>(null)
-    override val currentFileId: StateFlow<Long?> = _currentFileId.asStateFlow()
+        private val _repeatMode = MutableStateFlow(RepeatMode.OFF)
+        override val repeatMode: StateFlow<RepeatMode> = _repeatMode.asStateFlow()
 
-    private val _repeatMode = MutableStateFlow(RepeatMode.OFF)
-    override val repeatMode: StateFlow<RepeatMode> = _repeatMode.asStateFlow()
+        private val _shuffleEnabled = MutableStateFlow(false)
+        override val shuffleEnabled: StateFlow<Boolean> = _shuffleEnabled.asStateFlow()
 
-    private val _shuffleEnabled = MutableStateFlow(false)
-    override val shuffleEnabled: StateFlow<Boolean> = _shuffleEnabled.asStateFlow()
+        private val _currentQueue = MutableStateFlow<List<QueueItem>>(emptyList())
+        override val currentQueue: StateFlow<List<QueueItem>> = _currentQueue.asStateFlow()
 
-    private val _currentQueue = MutableStateFlow<List<QueueItem>>(emptyList())
-    override val currentQueue: StateFlow<List<QueueItem>> = _currentQueue.asStateFlow()
+        private val _loopRegion = MutableStateFlow<LoopRegion?>(null)
+        override val loopRegion: StateFlow<LoopRegion?> = _loopRegion.asStateFlow()
 
-    private val _loopRegion = MutableStateFlow<LoopRegion?>(null)
-    override val loopRegion: StateFlow<LoopRegion?> = _loopRegion.asStateFlow()
+        // Local queue metadata — kept in sync with ExoPlayer's media items
+        private val queueItems = mutableListOf<QueueItem>()
 
-    // Local queue metadata — kept in sync with ExoPlayer's media items
-    private val queueItems = mutableListOf<QueueItem>()
+        init {
+            connectToService()
+        }
 
-    init {
-        connectToService()
-    }
+        private fun connectToService() {
+            if (isConnecting || browser != null) return
+            isConnecting = true
 
-    private fun connectToService() {
-        if (isConnecting || browser != null) return
-        isConnecting = true
+            scope.launch {
+                try {
+                    val token =
+                        SessionToken(
+                            context,
+                            ComponentName(context, RehearsAllPlaybackService::class.java),
+                        )
+                    val mediaBrowser =
+                        MediaBrowser.Builder(context, token)
+                            .buildAsync()
+                            .await()
 
-        scope.launch {
-            try {
-                val token = SessionToken(
-                    context,
-                    ComponentName(context, RehearsAllPlaybackService::class.java),
+                    browser = mediaBrowser
+                    isConnecting = false
+
+                    // Sync initial state
+                    syncState(mediaBrowser)
+
+                    // Listen for player state changes
+                    mediaBrowser.addListener(
+                        object : Player.Listener {
+                            override fun onIsPlayingChanged(isPlaying: Boolean) {
+                                syncState(mediaBrowser)
+                                if (isPlaying) startPolling() else stopPolling()
+                            }
+
+                            override fun onPlaybackStateChanged(state: Int) {
+                                syncState(mediaBrowser)
+                            }
+
+                            override fun onMediaItemTransition(
+                                mediaItem: MediaItem?,
+                                reason: Int,
+                            ) {
+                                syncState(mediaBrowser)
+                            }
+
+                            override fun onRepeatModeChanged(mode: Int) {
+                                _repeatMode.value = RepeatMode.fromExoPlayer(mode)
+                            }
+
+                            override fun onShuffleModeEnabledChanged(shuffleModeEnabled: Boolean) {
+                                _shuffleEnabled.value = shuffleModeEnabled
+                            }
+
+                            override fun onPlaybackParametersChanged(playbackParameters: PlaybackParameters) {
+                                updatePlaybackState(mediaBrowser)
+                            }
+                        },
+                    )
+
+                    if (mediaBrowser.isPlaying) startPolling()
+
+                    Timber.i("Connected to PlaybackService")
+                } catch (e: Exception) {
+                    isConnecting = false
+                    Timber.e(e, "Failed to connect to PlaybackService")
+                }
+            }
+        }
+
+        // -- Position polling --
+
+        private var pollingJob: kotlinx.coroutines.Job? = null
+
+        private fun startPolling() {
+            if (pollingJob?.isActive == true) return
+            pollingJob =
+                scope.launch {
+                    while (true) {
+                        val b = browser ?: break
+                        updatePlaybackState(b)
+                        delay(16) // ~60fps for smooth scrubber
+                    }
+                }
+        }
+
+        private fun stopPolling() {
+            pollingJob?.cancel()
+            pollingJob = null
+            // One final sync so position is accurate when paused
+            browser?.let { updatePlaybackState(it) }
+        }
+
+        private fun syncState(player: MediaBrowser) {
+            _repeatMode.value = RepeatMode.fromExoPlayer(player.repeatMode)
+            _shuffleEnabled.value = player.shuffleModeEnabled
+            updatePlaybackState(player)
+
+            // Extract fileId from MediaItem extras
+            val fileId = player.currentMediaItem?.mediaId?.toLongOrNull()
+            _currentFileId.value = fileId
+
+            // Update queue with now-playing indicator
+            updateQueueState(fileId)
+        }
+
+        private fun updateQueueState(currentFileId: Long?) {
+            val currentIndex = browser?.currentMediaItemIndex ?: -1
+            _currentQueue.value =
+                queueItems.mapIndexed { index, item ->
+                    item.copy(isCurrentlyPlaying = index == currentIndex)
+                }
+        }
+
+        private fun updatePlaybackState(player: MediaBrowser) {
+            _playbackState.value =
+                PlaybackState(
+                    positionMs = player.currentPosition.coerceAtLeast(0L),
+                    durationMs = player.duration.coerceAtLeast(0L),
+                    isPlaying = player.isPlaying,
+                    speed = player.playbackParameters.speed,
                 )
-                val mediaBrowser = MediaBrowser.Builder(context, token)
-                    .buildAsync()
-                    .await()
+        }
 
-                browser = mediaBrowser
-                isConnecting = false
+        // -- Transport --
 
-                // Sync initial state
-                syncState(mediaBrowser)
+        override fun play() {
+            browser?.play()
+        }
 
-                // Listen for player state changes
-                mediaBrowser.addListener(object : Player.Listener {
-                    override fun onIsPlayingChanged(isPlaying: Boolean) {
-                        syncState(mediaBrowser)
-                        if (isPlaying) startPolling() else stopPolling()
-                    }
+        override fun pause() {
+            browser?.pause()
+        }
 
-                    override fun onPlaybackStateChanged(state: Int) {
-                        syncState(mediaBrowser)
-                    }
+        override fun seekTo(positionMs: Long) {
+            browser?.seekTo(positionMs)
+            // Immediately update local state for responsive UI
+            _playbackState.value = _playbackState.value.copy(positionMs = positionMs)
+        }
 
-                    override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
-                        syncState(mediaBrowser)
-                    }
+        override fun skipForward(ms: Long) {
+            val b = browser ?: return
+            val newPos = (b.currentPosition + ms).coerceAtMost(b.duration)
+            seekTo(newPos)
+        }
 
-                    override fun onRepeatModeChanged(mode: Int) {
-                        _repeatMode.value = RepeatMode.fromExoPlayer(mode)
-                    }
+        override fun skipBackward(ms: Long) {
+            val b = browser ?: return
+            val newPos = (b.currentPosition - ms).coerceAtLeast(0L)
+            seekTo(newPos)
+        }
 
-                    override fun onShuffleModeEnabledChanged(shuffleModeEnabled: Boolean) {
-                        _shuffleEnabled.value = shuffleModeEnabled
-                    }
+        override fun skipToNext() {
+            browser?.seekToNextMediaItem()
+        }
 
-                    override fun onPlaybackParametersChanged(playbackParameters: PlaybackParameters) {
-                        updatePlaybackState(mediaBrowser)
-                    }
-                })
-
-                if (mediaBrowser.isPlaying) startPolling()
-
-                Timber.i("Connected to PlaybackService")
-            } catch (e: Exception) {
-                isConnecting = false
-                Timber.e(e, "Failed to connect to PlaybackService")
+        override fun skipToPrevious() {
+            val b = browser ?: return
+            // If more than 3 s into the track, or no previous item exists, restart from the beginning.
+            // Otherwise, skip to the previous track in the queue.
+            if (b.currentPosition > 3_000L || !b.hasPreviousMediaItem()) {
+                b.seekTo(0L)
+                _playbackState.value = _playbackState.value.copy(positionMs = 0L)
+            } else {
+                b.seekToPreviousMediaItem()
             }
         }
-    }
 
-    // -- Position polling --
+        // -- Speed --
 
-    private var pollingJob: kotlinx.coroutines.Job? = null
-
-    private fun startPolling() {
-        if (pollingJob?.isActive == true) return
-        pollingJob = scope.launch {
-            while (true) {
-                val b = browser ?: break
-                updatePlaybackState(b)
-                delay(16) // ~60fps for smooth scrubber
-            }
-        }
-    }
-
-    private fun stopPolling() {
-        pollingJob?.cancel()
-        pollingJob = null
-        // One final sync so position is accurate when paused
-        browser?.let { updatePlaybackState(it) }
-    }
-
-    private fun syncState(player: MediaBrowser) {
-        _repeatMode.value = RepeatMode.fromExoPlayer(player.repeatMode)
-        _shuffleEnabled.value = player.shuffleModeEnabled
-        updatePlaybackState(player)
-
-        // Extract fileId from MediaItem extras
-        val fileId = player.currentMediaItem?.mediaId?.toLongOrNull()
-        _currentFileId.value = fileId
-
-        // Update queue with now-playing indicator
-        updateQueueState(fileId)
-    }
-
-    private fun updateQueueState(currentFileId: Long?) {
-        val currentIndex = browser?.currentMediaItemIndex ?: -1
-        _currentQueue.value = queueItems.mapIndexed { index, item ->
-            item.copy(isCurrentlyPlaying = index == currentIndex)
-        }
-    }
-
-    private fun updatePlaybackState(player: MediaBrowser) {
-        _playbackState.value = PlaybackState(
-            positionMs = player.currentPosition.coerceAtLeast(0L),
-            durationMs = player.duration.coerceAtLeast(0L),
-            isPlaying = player.isPlaying,
-            speed = player.playbackParameters.speed,
-        )
-    }
-
-    // -- Transport --
-
-    override fun play() {
-        browser?.play()
-    }
-
-    override fun pause() {
-        browser?.pause()
-    }
-
-    override fun seekTo(positionMs: Long) {
-        browser?.seekTo(positionMs)
-        // Immediately update local state for responsive UI
-        _playbackState.value = _playbackState.value.copy(positionMs = positionMs)
-    }
-
-    override fun skipForward(ms: Long) {
-        val b = browser ?: return
-        val newPos = (b.currentPosition + ms).coerceAtMost(b.duration)
-        seekTo(newPos)
-    }
-
-    override fun skipBackward(ms: Long) {
-        val b = browser ?: return
-        val newPos = (b.currentPosition - ms).coerceAtLeast(0L)
-        seekTo(newPos)
-    }
-
-    override fun skipToNext() {
-        browser?.seekToNextMediaItem()
-    }
-
-    override fun skipToPrevious() {
-        val b = browser ?: return
-        // If more than 3 s into the track, or no previous item exists, restart from the beginning.
-        // Otherwise, skip to the previous track in the queue.
-        if (b.currentPosition > 3_000L || !b.hasPreviousMediaItem()) {
-            b.seekTo(0L)
-            _playbackState.value = _playbackState.value.copy(positionMs = 0L)
-        } else {
-            b.seekToPreviousMediaItem()
-        }
-    }
-
-    // -- Speed --
-
-    override fun setSpeed(speed: Float) {
-        val b = browser ?: return
-        val args = Bundle().apply {
-            putFloat(RehearsAllPlaybackService.ARG_SPEED, speed)
-        }
-        b.sendCustomCommand(
-            SessionCommand(RehearsAllPlaybackService.CMD_SET_SPEED, Bundle.EMPTY),
-            args,
-        )
-        // Optimistic UI update
-        _playbackState.value = _playbackState.value.copy(
-            speed = (speed * 20).toInt() / 20f
-        )
-    }
-
-    // -- Queue --
-
-    override fun playFile(fileId: Long, path: String, startPositionMs: Long) {
-        val b = browser ?: run {
-            Timber.w("Browser not connected, cannot play file %d", fileId)
-            return
-        }
-
-        val mediaItem = buildMediaItem(fileId, path)
-
-        b.setMediaItem(mediaItem, startPositionMs)
-        b.prepare()
-        b.play()
-
-        queueItems.clear()
-        queueItems.add(QueueItem(fileId, "", null, 0L, path))
-        _currentFileId.value = fileId
-        updateQueueState(fileId)
-        Timber.i("Playing file id=%d from %dms", fileId, startPositionMs)
-    }
-
-    override fun setQueue(items: List<QueueItem>, startIndex: Int) {
-        val b = browser ?: return
-        val mediaItems = items.map { buildMediaItem(it.fileId, it.path) }
-
-        b.setMediaItems(mediaItems, startIndex, 0L)
-        b.prepare()
-        b.play()
-
-        queueItems.clear()
-        queueItems.addAll(items)
-        updateQueueState(items.getOrNull(startIndex)?.fileId)
-        Timber.i("Queue set: %d items, starting at index %d", items.size, startIndex)
-    }
-
-    override fun skipToQueueItem(index: Int) {
-        val b = browser ?: return
-        if (index in 0 until b.mediaItemCount) {
-            b.seekToDefaultPosition(index)
-        }
-    }
-
-    override fun removeFromQueue(index: Int) {
-        val b = browser ?: return
-        if (index in 0 until b.mediaItemCount) {
-            b.removeMediaItem(index)
-            if (index < queueItems.size) {
-                queueItems.removeAt(index)
-            }
-            updateQueueState(_currentFileId.value)
-        }
-    }
-
-    override fun moveQueueItem(fromIndex: Int, toIndex: Int) {
-        val b = browser ?: return
-        if (fromIndex in 0 until b.mediaItemCount && toIndex in 0 until b.mediaItemCount) {
-            b.moveMediaItem(fromIndex, toIndex)
-            if (fromIndex < queueItems.size && toIndex <= queueItems.size) {
-                val item = queueItems.removeAt(fromIndex)
-                queueItems.add(toIndex.coerceAtMost(queueItems.size), item)
-            }
-            updateQueueState(_currentFileId.value)
-        }
-    }
-
-    override fun clearQueue() {
-        val b = browser ?: return
-        b.clearMediaItems()
-        queueItems.clear()
-        _currentQueue.value = emptyList()
-        _currentFileId.value = null
-    }
-
-    private fun buildMediaItem(fileId: Long, path: String): MediaItem {
-        return MediaItem.Builder()
-            .setMediaId(fileId.toString())
-            .setUri(path)
-            .setMediaMetadata(
-                MediaMetadata.Builder()
-                    .setExtras(Bundle().apply { putLong("fileId", fileId) })
-                    .build()
+        override fun setSpeed(speed: Float) {
+            val b = browser ?: return
+            val args =
+                Bundle().apply {
+                    putFloat(RehearsAllPlaybackService.ARG_SPEED, speed)
+                }
+            b.sendCustomCommand(
+                SessionCommand(RehearsAllPlaybackService.CMD_SET_SPEED, Bundle.EMPTY),
+                args,
             )
-            .build()
-    }
-
-    override fun setRepeatMode(mode: RepeatMode) {
-        browser?.repeatMode = mode.exoPlayerMode
-        _repeatMode.value = mode
-    }
-
-    override fun setShuffleEnabled(enabled: Boolean) {
-        browser?.shuffleModeEnabled = enabled
-        _shuffleEnabled.value = enabled
-    }
-
-    // -- A-B Loop --
-
-    override fun setLoopRegion(region: LoopRegion) {
-        val b = browser ?: return
-        val args = Bundle().apply {
-            putLong(RehearsAllPlaybackService.ARG_LOOP_START, region.startMs)
-            putLong(RehearsAllPlaybackService.ARG_LOOP_END, region.endMs)
+            // Optimistic UI update
+            _playbackState.value =
+                _playbackState.value.copy(
+                    speed = (speed * 20).toInt() / 20f,
+                )
         }
-        b.sendCustomCommand(
-            SessionCommand(RehearsAllPlaybackService.CMD_SET_LOOP_REGION, Bundle.EMPTY),
-            args,
-        )
-        _loopRegion.value = region
-    }
 
-    override fun clearLoopRegion() {
-        val b = browser ?: return
-        b.sendCustomCommand(
-            SessionCommand(RehearsAllPlaybackService.CMD_CLEAR_LOOP_REGION, Bundle.EMPTY),
-            Bundle.EMPTY,
-        )
-        _loopRegion.value = null
-    }
+        // -- Queue --
 
-    // -- Lifecycle --
+        override fun playFile(
+            fileId: Long,
+            path: String,
+            startPositionMs: Long,
+        ) {
+            val b =
+                browser ?: run {
+                    Timber.w("Browser not connected, cannot play file %d", fileId)
+                    return
+                }
 
-    override fun release() {
-        stopPolling()
-        browser?.release()
-        browser = null
-        scope.cancel()
-        Timber.i("PlaybackManager released")
+            val mediaItem = buildMediaItem(fileId, path)
+
+            b.setMediaItem(mediaItem, startPositionMs)
+            b.prepare()
+            b.play()
+
+            queueItems.clear()
+            queueItems.add(QueueItem(fileId, "", null, 0L, path))
+            _currentFileId.value = fileId
+            updateQueueState(fileId)
+            Timber.i("Playing file id=%d from %dms", fileId, startPositionMs)
+        }
+
+        override fun setQueue(
+            items: List<QueueItem>,
+            startIndex: Int,
+        ) {
+            val b = browser ?: return
+            val mediaItems = items.map { buildMediaItem(it.fileId, it.path) }
+
+            b.setMediaItems(mediaItems, startIndex, 0L)
+            b.prepare()
+            b.play()
+
+            queueItems.clear()
+            queueItems.addAll(items)
+            updateQueueState(items.getOrNull(startIndex)?.fileId)
+            Timber.i("Queue set: %d items, starting at index %d", items.size, startIndex)
+        }
+
+        override fun skipToQueueItem(index: Int) {
+            val b = browser ?: return
+            if (index in 0 until b.mediaItemCount) {
+                b.seekToDefaultPosition(index)
+            }
+        }
+
+        override fun removeFromQueue(index: Int) {
+            val b = browser ?: return
+            if (index in 0 until b.mediaItemCount) {
+                b.removeMediaItem(index)
+                if (index < queueItems.size) {
+                    queueItems.removeAt(index)
+                }
+                updateQueueState(_currentFileId.value)
+            }
+        }
+
+        override fun moveQueueItem(
+            fromIndex: Int,
+            toIndex: Int,
+        ) {
+            val b = browser ?: return
+            if (fromIndex in 0 until b.mediaItemCount && toIndex in 0 until b.mediaItemCount) {
+                b.moveMediaItem(fromIndex, toIndex)
+                if (fromIndex < queueItems.size && toIndex <= queueItems.size) {
+                    val item = queueItems.removeAt(fromIndex)
+                    queueItems.add(toIndex.coerceAtMost(queueItems.size), item)
+                }
+                updateQueueState(_currentFileId.value)
+            }
+        }
+
+        override fun clearQueue() {
+            val b = browser ?: return
+            b.clearMediaItems()
+            queueItems.clear()
+            _currentQueue.value = emptyList()
+            _currentFileId.value = null
+        }
+
+        private fun buildMediaItem(
+            fileId: Long,
+            path: String,
+        ): MediaItem {
+            return MediaItem.Builder()
+                .setMediaId(fileId.toString())
+                .setUri(path)
+                .setMediaMetadata(
+                    MediaMetadata.Builder()
+                        .setExtras(Bundle().apply { putLong("fileId", fileId) })
+                        .build(),
+                )
+                .build()
+        }
+
+        override fun setRepeatMode(mode: RepeatMode) {
+            browser?.repeatMode = mode.exoPlayerMode
+            _repeatMode.value = mode
+        }
+
+        override fun setShuffleEnabled(enabled: Boolean) {
+            browser?.shuffleModeEnabled = enabled
+            _shuffleEnabled.value = enabled
+        }
+
+        // -- A-B Loop --
+
+        override fun setLoopRegion(region: LoopRegion) {
+            val b = browser ?: return
+            val args =
+                Bundle().apply {
+                    putLong(RehearsAllPlaybackService.ARG_LOOP_START, region.startMs)
+                    putLong(RehearsAllPlaybackService.ARG_LOOP_END, region.endMs)
+                }
+            b.sendCustomCommand(
+                SessionCommand(RehearsAllPlaybackService.CMD_SET_LOOP_REGION, Bundle.EMPTY),
+                args,
+            )
+            _loopRegion.value = region
+        }
+
+        override fun clearLoopRegion() {
+            val b = browser ?: return
+            b.sendCustomCommand(
+                SessionCommand(RehearsAllPlaybackService.CMD_CLEAR_LOOP_REGION, Bundle.EMPTY),
+                Bundle.EMPTY,
+            )
+            _loopRegion.value = null
+        }
+
+        // -- Lifecycle --
+
+        override fun release() {
+            stopPolling()
+            browser?.release()
+            browser = null
+            scope.cancel()
+            Timber.i("PlaybackManager released")
+        }
     }
-}

--- a/app/src/main/java/com/rehearsall/playback/RehearsAllPlaybackService.kt
+++ b/app/src/main/java/com/rehearsall/playback/RehearsAllPlaybackService.kt
@@ -20,13 +20,9 @@ import androidx.media3.session.SessionResult
 import com.google.common.collect.ImmutableList
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
-import com.rehearsall.data.db.dao.AudioFileDao
-import com.rehearsall.data.db.dao.LoopDao
-import com.rehearsall.data.db.dao.PlaylistDao
-import com.rehearsall.data.db.dao.PlaylistItemDao
+import com.rehearsall.data.preferences.UserPreferencesRepository
 import com.rehearsall.di.ServiceEntryPoint
 import dagger.hilt.android.EntryPointAccessors
-import com.rehearsall.data.preferences.UserPreferencesRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -48,7 +44,6 @@ import timber.log.Timber
  * Also serves the Android Auto content tree via MediaLibrarySession.Callback.
  */
 class RehearsAllPlaybackService : MediaLibraryService() {
-
     companion object {
         const val CMD_SET_SPEED = "com.rehearsall.CMD_SET_SPEED"
         const val CMD_GET_SPEED = "com.rehearsall.CMD_GET_SPEED"
@@ -78,59 +73,67 @@ class RehearsAllPlaybackService : MediaLibraryService() {
         Timber.i("PlaybackService created")
 
         // Access DAOs via Hilt EntryPoint (service can't use @AndroidEntryPoint with MediaLibraryService)
-        val entryPoint = EntryPointAccessors.fromApplication(
-            applicationContext,
-            ServiceEntryPoint::class.java,
-        )
-        contentTreeBuilder = ContentTreeBuilder(
-            audioFileDao = entryPoint.audioFileDao(),
-            playlistDao = entryPoint.playlistDao(),
-            playlistItemDao = entryPoint.playlistItemDao(),
-            loopDao = entryPoint.loopDao(),
-        )
+        val entryPoint =
+            EntryPointAccessors.fromApplication(
+                applicationContext,
+                ServiceEntryPoint::class.java,
+            )
+        contentTreeBuilder =
+            ContentTreeBuilder(
+                audioFileDao = entryPoint.audioFileDao(),
+                playlistDao = entryPoint.playlistDao(),
+                playlistItemDao = entryPoint.playlistItemDao(),
+                loopDao = entryPoint.loopDao(),
+            )
         loopActionHandler = LoopActionHandler(entryPoint.loopDao())
         userPreferencesRepository = entryPoint.userPreferencesRepository()
 
-        val audioAttributes = AudioAttributes.Builder()
-            .setUsage(C.USAGE_MEDIA)
-            .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
-            .build()
+        val audioAttributes =
+            AudioAttributes.Builder()
+                .setUsage(C.USAGE_MEDIA)
+                .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
+                .build()
 
-        val exoPlayer = ExoPlayer.Builder(this)
-            .setAudioAttributes(audioAttributes, /* handleAudioFocus= */ true)
-            .setHandleAudioBecomingNoisy(true)
-            .build()
+        val exoPlayer =
+            ExoPlayer.Builder(this)
+                .setAudioAttributes(audioAttributes, /* handleAudioFocus= */ true)
+                .setHandleAudioBecomingNoisy(true)
+                .build()
 
-        exoPlayer.addListener(object : Player.Listener {
-            override fun onIsPlayingChanged(isPlaying: Boolean) {
-                if (isPlaying && loopRegion != null) {
-                    startLoopPolling(exoPlayer)
-                } else {
-                    stopLoopPolling()
+        exoPlayer.addListener(
+            object : Player.Listener {
+                override fun onIsPlayingChanged(isPlaying: Boolean) {
+                    if (isPlaying && loopRegion != null) {
+                        startLoopPolling(exoPlayer)
+                    } else {
+                        stopLoopPolling()
+                    }
                 }
-            }
 
-            override fun onPlaybackStateChanged(playbackState: Int) {
-                if (playbackState == Player.STATE_ENDED && loopRegion != null) {
-                    val region = loopRegion ?: return
-                    exoPlayer.seekTo(region.startMs)
-                    exoPlayer.play()
+                override fun onPlaybackStateChanged(playbackState: Int) {
+                    if (playbackState == Player.STATE_ENDED && loopRegion != null) {
+                        val region = loopRegion ?: return
+                        exoPlayer.seekTo(region.startMs)
+                        exoPlayer.play()
+                    }
                 }
-            }
-        })
+            },
+        )
 
         player = exoPlayer
 
-        val pendingIntent = PendingIntent.getActivity(
-            this,
-            0,
-            packageManager.getLaunchIntentForPackage(packageName),
-            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
-        )
+        val pendingIntent =
+            PendingIntent.getActivity(
+                this,
+                0,
+                packageManager.getLaunchIntentForPackage(packageName),
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
 
-        session = MediaLibrarySession.Builder(this, exoPlayer, LibrarySessionCallback())
-            .setSessionActivity(pendingIntent)
-            .build()
+        session =
+            MediaLibrarySession.Builder(this, exoPlayer, LibrarySessionCallback())
+                .setSessionActivity(pendingIntent)
+                .build()
     }
 
     override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaLibrarySession? {
@@ -158,49 +161,50 @@ class RehearsAllPlaybackService : MediaLibraryService() {
 
     private fun startLoopPolling(exoPlayer: ExoPlayer) {
         stopLoopPolling()
-        loopPollingJob = serviceScope.launch {
-            val crossfadeEnabled = userPreferencesRepository.loopCrossfade.first()
-            val fadeMs = 50L
-            var fadingIn = false
-            var fadeInStart = 0L
+        loopPollingJob =
+            serviceScope.launch {
+                val crossfadeEnabled = userPreferencesRepository.loopCrossfade.first()
+                val fadeMs = 50L
+                var fadingIn = false
+                var fadeInStart = 0L
 
-            while (true) {
-                val region = loopRegion ?: break
-                val pos = exoPlayer.currentPosition
-                val loopLen = region.endMs - region.startMs
+                while (true) {
+                    val region = loopRegion ?: break
+                    val pos = exoPlayer.currentPosition
+                    val loopLen = region.endMs - region.startMs
 
-                // Disable crossfade for very short loops (< 150ms)
-                val useCrossfade = crossfadeEnabled && loopLen >= 150
+                    // Disable crossfade for very short loops (< 150ms)
+                    val useCrossfade = crossfadeEnabled && loopLen >= 150
 
-                if (pos >= region.endMs || pos < region.startMs - 500) {
-                    if (useCrossfade) {
-                        exoPlayer.volume = 0f
-                        exoPlayer.seekTo(region.startMs)
-                        fadingIn = true
-                        fadeInStart = System.currentTimeMillis()
-                    } else {
-                        exoPlayer.seekTo(region.startMs)
+                    if (pos >= region.endMs || pos < region.startMs - 500) {
+                        if (useCrossfade) {
+                            exoPlayer.volume = 0f
+                            exoPlayer.seekTo(region.startMs)
+                            fadingIn = true
+                            fadeInStart = System.currentTimeMillis()
+                        } else {
+                            exoPlayer.seekTo(region.startMs)
+                        }
+                    } else if (useCrossfade) {
+                        val msUntilEnd = region.endMs - pos
+                        if (fadingIn) {
+                            // Fade volume back in after seek
+                            val elapsed = System.currentTimeMillis() - fadeInStart
+                            val progress = (elapsed.toFloat() / fadeMs).coerceIn(0f, 1f)
+                            exoPlayer.volume = progress
+                            if (progress >= 1f) fadingIn = false
+                        } else if (msUntilEnd <= fadeMs) {
+                            // Fade out approaching loop end
+                            val progress = (msUntilEnd.toFloat() / fadeMs).coerceIn(0f, 1f)
+                            exoPlayer.volume = progress
+                        } else {
+                            exoPlayer.volume = 1f
+                        }
                     }
-                } else if (useCrossfade) {
-                    val msUntilEnd = region.endMs - pos
-                    if (fadingIn) {
-                        // Fade volume back in after seek
-                        val elapsed = System.currentTimeMillis() - fadeInStart
-                        val progress = (elapsed.toFloat() / fadeMs).coerceIn(0f, 1f)
-                        exoPlayer.volume = progress
-                        if (progress >= 1f) fadingIn = false
-                    } else if (msUntilEnd <= fadeMs) {
-                        // Fade out approaching loop end
-                        val progress = (msUntilEnd.toFloat() / fadeMs).coerceIn(0f, 1f)
-                        exoPlayer.volume = progress
-                    } else {
-                        exoPlayer.volume = 1f
-                    }
+
+                    delay(16) // ~60fps polling for smooth crossfade
                 }
-
-                delay(16) // ~60fps polling for smooth crossfade
             }
-        }
     }
 
     private fun stopLoopPolling() {
@@ -214,19 +218,19 @@ class RehearsAllPlaybackService : MediaLibraryService() {
      */
     @OptIn(UnstableApi::class)
     private inner class LibrarySessionCallback : MediaLibrarySession.Callback {
-
         override fun onConnect(
             session: MediaSession,
             controller: MediaSession.ControllerInfo,
         ): MediaSession.ConnectionResult {
-            val sessionCommands = MediaSession.ConnectionResult.DEFAULT_SESSION_AND_LIBRARY_COMMANDS
-                .buildUpon()
-                .add(SessionCommand(CMD_SET_SPEED, Bundle.EMPTY))
-                .add(SessionCommand(CMD_GET_SPEED, Bundle.EMPTY))
-                .add(SessionCommand(CMD_SET_LOOP_REGION, Bundle.EMPTY))
-                .add(SessionCommand(CMD_CLEAR_LOOP_REGION, Bundle.EMPTY))
-                .add(SessionCommand(LoopActionHandler.ACTION_TOGGLE_LOOP, Bundle.EMPTY))
-                .build()
+            val sessionCommands =
+                MediaSession.ConnectionResult.DEFAULT_SESSION_AND_LIBRARY_COMMANDS
+                    .buildUpon()
+                    .add(SessionCommand(CMD_SET_SPEED, Bundle.EMPTY))
+                    .add(SessionCommand(CMD_GET_SPEED, Bundle.EMPTY))
+                    .add(SessionCommand(CMD_SET_LOOP_REGION, Bundle.EMPTY))
+                    .add(SessionCommand(CMD_CLEAR_LOOP_REGION, Bundle.EMPTY))
+                    .add(SessionCommand(LoopActionHandler.ACTION_TOGGLE_LOOP, Bundle.EMPTY))
+                    .build()
 
             return MediaSession.ConnectionResult.AcceptedResultBuilder(session)
                 .setAvailableSessionCommands(sessionCommands)
@@ -310,21 +314,22 @@ class RehearsAllPlaybackService : MediaLibraryService() {
         ): ListenableFuture<MutableList<MediaItem>> {
             return serviceScope.future {
                 // Resolve media items — add URI and handle loop activation
-                val resolved = mediaItems.map { item ->
-                    val resolvedItem = contentTreeBuilder.getItem(item.mediaId) ?: item
+                val resolved =
+                    mediaItems.map { item ->
+                        val resolvedItem = contentTreeBuilder.getItem(item.mediaId) ?: item
 
-                    // If this is a loop item, activate the loop region
-                    val loopInfo = loopActionHandler.parseLoopFromMediaItem(resolvedItem)
-                    if (loopInfo != null) {
-                        loopRegion = loopInfo
-                        Timber.d("Auto: activated loop %d-%d ms", loopInfo.startMs, loopInfo.endMs)
-                    } else if (item.mediaId.endsWith(":full") || !item.mediaId.contains(":loop:")) {
-                        // Full track or regular file — clear any active loop
-                        loopRegion = null
+                        // If this is a loop item, activate the loop region
+                        val loopInfo = loopActionHandler.parseLoopFromMediaItem(resolvedItem)
+                        if (loopInfo != null) {
+                            loopRegion = loopInfo
+                            Timber.d("Auto: activated loop %d-%d ms", loopInfo.startMs, loopInfo.endMs)
+                        } else if (item.mediaId.endsWith(":full") || !item.mediaId.contains(":loop:")) {
+                            // Full track or regular file — clear any active loop
+                            loopRegion = null
+                        }
+
+                        resolvedItem
                     }
-
-                    resolvedItem
-                }
                 resolved.toMutableList()
             }
         }
@@ -338,14 +343,16 @@ class RehearsAllPlaybackService : MediaLibraryService() {
             customCommand: SessionCommand,
             args: Bundle,
         ): ListenableFuture<SessionResult> {
-            val p = player ?: return Futures.immediateFuture(
-                SessionResult(SessionResult.RESULT_ERROR_UNKNOWN)
-            )
+            val p =
+                player ?: return Futures.immediateFuture(
+                    SessionResult(SessionResult.RESULT_ERROR_UNKNOWN),
+                )
 
             return when (customCommand.customAction) {
                 CMD_SET_SPEED -> {
-                    val speed = args.getFloat(ARG_SPEED, 1.0f)
-                        .coerceIn(0.25f, 3.0f)
+                    val speed =
+                        args.getFloat(ARG_SPEED, 1.0f)
+                            .coerceIn(0.25f, 3.0f)
                     val rounded = (speed * 20).toInt() / 20f
                     p.playbackParameters = PlaybackParameters(rounded)
                     Timber.d("Speed set to %.2fx", rounded)
@@ -353,9 +360,10 @@ class RehearsAllPlaybackService : MediaLibraryService() {
                 }
 
                 CMD_GET_SPEED -> {
-                    val result = Bundle().apply {
-                        putFloat(ARG_SPEED, p.playbackParameters.speed)
-                    }
+                    val result =
+                        Bundle().apply {
+                            putFloat(ARG_SPEED, p.playbackParameters.speed)
+                        }
                     Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS, result))
                 }
 
@@ -379,20 +387,22 @@ class RehearsAllPlaybackService : MediaLibraryService() {
 
                 LoopActionHandler.ACTION_TOGGLE_LOOP -> {
                     serviceScope.future {
-                        val currentFileId = p.currentMediaItem?.mediaId
-                            ?.removePrefix("file:")
-                            ?.split(":")
-                            ?.firstOrNull()
-                            ?.toLongOrNull()
+                        val currentFileId =
+                            p.currentMediaItem?.mediaId
+                                ?.removePrefix("file:")
+                                ?.split(":")
+                                ?.firstOrNull()
+                                ?.toLongOrNull()
                         val newRegion = loopActionHandler.handleToggle(currentFileId, loopRegion)
                         loopRegion = newRegion
                         SessionResult(SessionResult.RESULT_SUCCESS)
                     }
                 }
 
-                else -> Futures.immediateFuture(
-                    SessionResult(SessionResult.RESULT_ERROR_NOT_SUPPORTED)
-                )
+                else ->
+                    Futures.immediateFuture(
+                        SessionResult(SessionResult.RESULT_ERROR_NOT_SUPPORTED),
+                    )
             }
         }
     }

--- a/app/src/main/java/com/rehearsall/playback/RehearsAllPlaybackService.kt
+++ b/app/src/main/java/com/rehearsall/playback/RehearsAllPlaybackService.kt
@@ -96,7 +96,8 @@ class RehearsAllPlaybackService : MediaLibraryService() {
 
         val exoPlayer =
             ExoPlayer.Builder(this)
-                .setAudioAttributes(audioAttributes, /* handleAudioFocus= */ true)
+                // handleAudioFocus = true
+                .setAudioAttributes(audioAttributes, true)
                 .setHandleAudioBecomingNoisy(true)
                 .build()
 

--- a/app/src/main/java/com/rehearsall/playback/RepeatMode.kt
+++ b/app/src/main/java/com/rehearsall/playback/RepeatMode.kt
@@ -5,13 +5,15 @@ import androidx.media3.common.Player
 enum class RepeatMode(val exoPlayerMode: Int) {
     OFF(Player.REPEAT_MODE_OFF),
     ONE(Player.REPEAT_MODE_ONE),
-    ALL(Player.REPEAT_MODE_ALL);
+    ALL(Player.REPEAT_MODE_ALL),
+    ;
 
-    fun next(): RepeatMode = when (this) {
-        OFF -> ONE
-        ONE -> ALL
-        ALL -> OFF
-    }
+    fun next(): RepeatMode =
+        when (this) {
+            OFF -> ONE
+            ONE -> ALL
+            ALL -> OFF
+        }
 
     companion object {
         fun fromExoPlayer(mode: Int): RepeatMode = entries.first { it.exoPlayerMode == mode }

--- a/app/src/main/java/com/rehearsall/ui/common/FileDetailsBottomSheet.kt
+++ b/app/src/main/java/com/rehearsall/ui/common/FileDetailsBottomSheet.kt
@@ -9,9 +9,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -53,9 +53,10 @@ fun FileDetailsBottomSheet(
         sheetState = sheetState,
     ) {
         Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 24.dp, vertical = 16.dp),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp, vertical = 16.dp),
         ) {
             Text(
                 text = audioFile.displayName,
@@ -99,9 +100,10 @@ fun FileDetailsBottomSheet(
 
                 TextButton(
                     onClick = onDelete,
-                    colors = androidx.compose.material3.ButtonDefaults.textButtonColors(
-                        contentColor = MaterialTheme.colorScheme.error,
-                    ),
+                    colors =
+                        androidx.compose.material3.ButtonDefaults.textButtonColors(
+                            contentColor = MaterialTheme.colorScheme.error,
+                        ),
                 ) {
                     Icon(Icons.Default.Delete, contentDescription = null)
                     Text("Delete", modifier = Modifier.padding(start = 8.dp))
@@ -136,11 +138,15 @@ fun FileDetailsBottomSheet(
 }
 
 @Composable
-private fun DetailRow(label: String, value: String) {
+private fun DetailRow(
+    label: String,
+    value: String,
+) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 4.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(vertical = 4.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         Text(
@@ -207,10 +213,11 @@ private fun PlaylistPickerDialog(
                 Column {
                     playlists.forEach { playlist ->
                         Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clickable { onSelect(playlist.id) }
-                                .padding(vertical = 12.dp),
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .clickable { onSelect(playlist.id) }
+                                    .padding(vertical = 12.dp),
                         ) {
                             Text(
                                 text = playlist.name,

--- a/app/src/main/java/com/rehearsall/ui/common/MiniPlayer.kt
+++ b/app/src/main/java/com/rehearsall/ui/common/MiniPlayer.kt
@@ -47,25 +47,28 @@ fun MiniPlayer(
         ) {
             Column {
                 // Thin progress bar
-                val progress = if (playbackState.durationMs > 0) {
-                    playbackState.positionMs.toFloat() / playbackState.durationMs.toFloat()
-                } else {
-                    0f
-                }
+                val progress =
+                    if (playbackState.durationMs > 0) {
+                        playbackState.positionMs.toFloat() / playbackState.durationMs.toFloat()
+                    } else {
+                        0f
+                    }
                 LinearProgressIndicator(
                     progress = { progress },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(2.dp),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .height(2.dp),
                     color = MaterialTheme.colorScheme.primary,
                     trackColor = MaterialTheme.colorScheme.surfaceVariant,
                 )
 
                 Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable(onClick = onTap)
-                        .padding(horizontal = 16.dp, vertical = 14.dp),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .clickable(onClick = onTap)
+                            .padding(horizontal = 16.dp, vertical = 14.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Text(
@@ -88,11 +91,12 @@ fun MiniPlayer(
                         modifier = Modifier.size(40.dp),
                     ) {
                         Icon(
-                            imageVector = if (playbackState.isPlaying) {
-                                Icons.Default.Pause
-                            } else {
-                                Icons.Default.PlayArrow
-                            },
+                            imageVector =
+                                if (playbackState.isPlaying) {
+                                    Icons.Default.Pause
+                                } else {
+                                    Icons.Default.PlayArrow
+                                },
                             contentDescription = if (playbackState.isPlaying) "Pause" else "Play",
                         )
                     }

--- a/app/src/main/java/com/rehearsall/ui/filelist/FileListScreen.kt
+++ b/app/src/main/java/com/rehearsall/ui/filelist/FileListScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.QueueMusic
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.AudioFile
 import androidx.compose.material.icons.filled.CheckCircle
@@ -30,8 +31,6 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.PlaylistAdd
-import androidx.compose.material.icons.filled.PlaylistPlay
-import androidx.compose.material.icons.automirrored.filled.QueueMusic
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
@@ -87,11 +86,12 @@ fun FileListScreen(
 
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
 
-    val safLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.OpenMultipleDocuments()
-    ) { uris: List<Uri> ->
-        viewModel.importFiles(uris)
-    }
+    val safLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.OpenMultipleDocuments(),
+        ) { uris: List<Uri> ->
+            viewModel.importFiles(uris)
+        }
 
     LaunchedEffect(Unit) {
         viewModel.events.collect { event ->
@@ -145,9 +145,15 @@ fun FileListScreen(
                 onClick = {
                     safLauncher.launch(
                         arrayOf(
-                            "audio/mpeg", "audio/wav", "audio/x-wav", "audio/ogg",
-                            "audio/flac", "audio/mp4", "audio/x-m4a", "audio/aac",
-                        )
+                            "audio/mpeg",
+                            "audio/wav",
+                            "audio/x-wav",
+                            "audio/ogg",
+                            "audio/flac",
+                            "audio/mp4",
+                            "audio/x-m4a",
+                            "audio/aac",
+                        ),
                     )
                 },
                 containerColor = MaterialTheme.colorScheme.primaryContainer,
@@ -160,9 +166,10 @@ fun FileListScreen(
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
     ) { innerPadding ->
         Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding),
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
         ) {
             if (isImporting) {
                 LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
@@ -309,9 +316,10 @@ private fun CombinedList(
         if (playlists.isNotEmpty() || true) { // Always show section for "New Playlist" button
             item(key = "playlists-header") {
                 Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 8.dp),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
@@ -355,33 +363,36 @@ private fun CombinedList(
             items = files,
             key = { "file-${it.id}" },
         ) { file ->
-            val dismissState = rememberSwipeToDismissBoxState(
-                confirmValueChange = { value ->
-                    if (value == SwipeToDismissBoxValue.EndToStart) {
-                        onFileDelete(file.id)
-                        true
-                    } else {
-                        false
-                    }
-                },
-            )
+            val dismissState =
+                rememberSwipeToDismissBoxState(
+                    confirmValueChange = { value ->
+                        if (value == SwipeToDismissBoxValue.EndToStart) {
+                            onFileDelete(file.id)
+                            true
+                        } else {
+                            false
+                        }
+                    },
+                )
 
             SwipeToDismissBox(
                 state = dismissState,
                 backgroundContent = {
                     val color by animateColorAsState(
-                        targetValue = if (dismissState.targetValue == SwipeToDismissBoxValue.EndToStart) {
-                            MaterialTheme.colorScheme.errorContainer
-                        } else {
-                            MaterialTheme.colorScheme.surface
-                        },
+                        targetValue =
+                            if (dismissState.targetValue == SwipeToDismissBoxValue.EndToStart) {
+                                MaterialTheme.colorScheme.errorContainer
+                            } else {
+                                MaterialTheme.colorScheme.surface
+                            },
                         label = "swipe-bg",
                     )
                     Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .background(color)
-                            .padding(horizontal = 24.dp),
+                        modifier =
+                            Modifier
+                                .fillMaxSize()
+                                .background(color)
+                                .padding(horizontal = 24.dp),
                         contentAlignment = Alignment.CenterEnd,
                     ) {
                         Icon(
@@ -410,15 +421,17 @@ private fun PlaylistCard(
     onClick: () -> Unit,
 ) {
     Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 2.dp)
-            .clickable(onClick = onClick),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 2.dp)
+                .clickable(onClick = onClick),
     ) {
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Icon(
@@ -460,10 +473,11 @@ private fun SelectionBar(
     onAddToPlaylist: () -> Unit,
 ) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(MaterialTheme.colorScheme.secondaryContainer)
-            .padding(horizontal = 8.dp, vertical = 4.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.secondaryContainer)
+                .padding(horizontal = 8.dp, vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         IconButton(
@@ -503,18 +517,20 @@ private fun AudioFileCard(
     onLongClick: () -> Unit,
 ) {
     Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 2.dp)
-            .combinedClickable(
-                onClick = onClick,
-                onLongClick = onLongClick,
-            ),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 2.dp)
+                .combinedClickable(
+                    onClick = onClick,
+                    onLongClick = onLongClick,
+                ),
     ) {
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             if (isSelected) {
@@ -568,7 +584,6 @@ private fun AudioFileCard(
                     color = MaterialTheme.colorScheme.outline,
                 )
             }
-
         }
     }
 }
@@ -589,10 +604,11 @@ private fun PlaylistPickerDialog(
                 LazyColumn {
                     items(items = playlists, key = { it.id }) { playlist ->
                         Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clickable { onSelect(playlist.id) }
-                                .padding(vertical = 12.dp, horizontal = 4.dp),
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .clickable { onSelect(playlist.id) }
+                                    .padding(vertical = 12.dp, horizontal = 4.dp),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
                             Icon(

--- a/app/src/main/java/com/rehearsall/ui/filelist/FileListUiState.kt
+++ b/app/src/main/java/com/rehearsall/ui/filelist/FileListUiState.kt
@@ -5,6 +5,7 @@ import com.rehearsall.domain.model.Playlist
 
 sealed interface FileListUiState {
     data object Loading : FileListUiState
+
     data class Loaded(
         val files: List<AudioFile>,
         val playlists: List<Playlist> = emptyList(),
@@ -12,16 +13,24 @@ sealed interface FileListUiState {
     ) : FileListUiState {
         val isInSelectionMode: Boolean get() = selectedFileIds.isNotEmpty()
     }
+
     data class Error(val message: String) : FileListUiState
 }
 
 sealed interface FileListEvent {
     data class ImportSuccess(val displayName: String) : FileListEvent
+
     data class ImportBatchComplete(val count: Int) : FileListEvent
+
     data class ImportError(val message: String) : FileListEvent
+
     data class DeleteSuccess(val displayName: String) : FileListEvent
+
     data class RenameSuccess(val newName: String) : FileListEvent
+
     data class PlaylistCreated(val name: String, val id: Long) : FileListEvent
+
     data class AddedToPlaylist(val fileName: String, val playlistName: String) : FileListEvent
+
     data class AddedBatchToPlaylist(val count: Int, val playlistName: String) : FileListEvent
 }

--- a/app/src/main/java/com/rehearsall/ui/filelist/FileListViewModel.kt
+++ b/app/src/main/java/com/rehearsall/ui/filelist/FileListViewModel.kt
@@ -23,183 +23,192 @@ import java.io.File
 import javax.inject.Inject
 
 @HiltViewModel
-class FileListViewModel @Inject constructor(
-    private val repository: AudioFileRepository,
-    private val playlistRepository: PlaylistRepository,
-    private val importer: AudioImporter,
-    private val playbackManager: PlaybackManager,
-) : ViewModel() {
+class FileListViewModel
+    @Inject
+    constructor(
+        private val repository: AudioFileRepository,
+        private val playlistRepository: PlaylistRepository,
+        private val importer: AudioImporter,
+        private val playbackManager: PlaybackManager,
+    ) : ViewModel() {
+        private val _uiState = MutableStateFlow<FileListUiState>(FileListUiState.Loading)
+        val uiState: StateFlow<FileListUiState> = _uiState.asStateFlow()
 
-    private val _uiState = MutableStateFlow<FileListUiState>(FileListUiState.Loading)
-    val uiState: StateFlow<FileListUiState> = _uiState.asStateFlow()
+        private val _events = MutableSharedFlow<FileListEvent>()
+        val events: SharedFlow<FileListEvent> = _events.asSharedFlow()
 
-    private val _events = MutableSharedFlow<FileListEvent>()
-    val events: SharedFlow<FileListEvent> = _events.asSharedFlow()
+        private val _isImporting = MutableStateFlow(false)
+        val isImporting: StateFlow<Boolean> = _isImporting.asStateFlow()
 
-    private val _isImporting = MutableStateFlow(false)
-    val isImporting: StateFlow<Boolean> = _isImporting.asStateFlow()
-
-    init {
-        viewModelScope.launch {
-            combine(
-                repository.getAllFiles(),
-                playlistRepository.getAllPlaylists(),
-            ) { files, playlists ->
-                FileListUiState.Loaded(files = files, playlists = playlists) as FileListUiState
-            }
-                .catch { e ->
-                    Timber.e(e, "Error loading files")
-                    emit(FileListUiState.Error("Failed to load files"))
+        init {
+            viewModelScope.launch {
+                combine(
+                    repository.getAllFiles(),
+                    playlistRepository.getAllPlaylists(),
+                ) { files, playlists ->
+                    FileListUiState.Loaded(files = files, playlists = playlists) as FileListUiState
                 }
-                .collect { _uiState.value = it }
+                    .catch { e ->
+                        Timber.e(e, "Error loading files")
+                        emit(FileListUiState.Error("Failed to load files"))
+                    }
+                    .collect { _uiState.value = it }
+            }
         }
-    }
 
-    fun importFile(uri: Uri) {
-        viewModelScope.launch {
-            _isImporting.value = true
-            val result = importer.import(uri)
-            _isImporting.value = false
+        fun importFile(uri: Uri) {
+            viewModelScope.launch {
+                _isImporting.value = true
+                val result = importer.import(uri)
+                _isImporting.value = false
 
-            result.fold(
-                onSuccess = { audioFile ->
-                    _events.emit(FileListEvent.ImportSuccess(audioFile.displayName))
-                },
-                onFailure = { error ->
-                    val message = error.message ?: "Import failed"
-                    _events.emit(FileListEvent.ImportError(message))
-                },
-            )
-        }
-    }
-
-    fun importFiles(uris: List<Uri>) {
-        if (uris.isEmpty()) return
-        if (uris.size == 1) {
-            importFile(uris.first())
-            return
-        }
-        viewModelScope.launch {
-            _isImporting.value = true
-            var successCount = 0
-            var errorCount = 0
-            for (uri in uris) {
-                importer.import(uri).fold(
-                    onSuccess = { successCount++ },
+                result.fold(
+                    onSuccess = { audioFile ->
+                        _events.emit(FileListEvent.ImportSuccess(audioFile.displayName))
+                    },
                     onFailure = { error ->
-                        errorCount++
-                        Timber.w("Batch import failed for %s: %s", uri, error.message)
+                        val message = error.message ?: "Import failed"
+                        _events.emit(FileListEvent.ImportError(message))
                     },
                 )
             }
-            _isImporting.value = false
-            if (successCount > 0) {
-                _events.emit(FileListEvent.ImportBatchComplete(successCount))
-            }
-            if (errorCount > 0) {
-                _events.emit(FileListEvent.ImportError("$errorCount file(s) failed to import"))
-            }
         }
-    }
 
-    fun toggleFileSelection(id: Long) {
-        val state = _uiState.value as? FileListUiState.Loaded ?: return
-        val newSelected = if (id in state.selectedFileIds) {
-            state.selectedFileIds - id
-        } else {
-            state.selectedFileIds + id
-        }
-        _uiState.value = state.copy(selectedFileIds = newSelected)
-    }
-
-    fun clearSelection() {
-        val state = _uiState.value as? FileListUiState.Loaded ?: return
-        _uiState.value = state.copy(selectedFileIds = emptySet())
-    }
-
-    fun addSelectedToPlaylist(playlistId: Long) {
-        val state = _uiState.value as? FileListUiState.Loaded ?: return
-        val selectedIds = state.selectedFileIds.toList()
-        if (selectedIds.isEmpty()) return
-        viewModelScope.launch {
-            val playlist = playlistRepository.getById(playlistId)
-            for (fileId in selectedIds) {
-                playlistRepository.addFileToPlaylist(playlistId, fileId)
+        fun importFiles(uris: List<Uri>) {
+            if (uris.isEmpty()) return
+            if (uris.size == 1) {
+                importFile(uris.first())
+                return
             }
-            clearSelection()
-            _events.emit(
-                FileListEvent.AddedBatchToPlaylist(
-                    count = selectedIds.size,
-                    playlistName = playlist?.name ?: "Playlist",
-                )
-            )
-        }
-    }
-
-    fun deleteFile(id: Long) {
-        viewModelScope.launch {
-            val file = repository.getById(id) ?: return@launch
-
-            try {
-                File(file.internalPath).delete()
-            } catch (e: Exception) {
-                Timber.w(e, "Failed to delete audio file: %s", file.internalPath)
-            }
-
-            try {
-                val waveformDir = File(file.internalPath).parentFile?.parentFile
-                waveformDir?.let {
-                    File(it, "waveforms/${file.id}.waveform").delete()
+            viewModelScope.launch {
+                _isImporting.value = true
+                var successCount = 0
+                var errorCount = 0
+                for (uri in uris) {
+                    importer.import(uri).fold(
+                        onSuccess = { successCount++ },
+                        onFailure = { error ->
+                            errorCount++
+                            Timber.w("Batch import failed for %s: %s", uri, error.message)
+                        },
+                    )
                 }
-            } catch (e: Exception) {
-                Timber.w(e, "Failed to delete waveform cache for id=%d", file.id)
+                _isImporting.value = false
+                if (successCount > 0) {
+                    _events.emit(FileListEvent.ImportBatchComplete(successCount))
+                }
+                if (errorCount > 0) {
+                    _events.emit(FileListEvent.ImportError("$errorCount file(s) failed to import"))
+                }
             }
-
-            repository.delete(id)
-            _events.emit(FileListEvent.DeleteSuccess(file.displayName))
         }
-    }
 
-    fun renameFile(id: Long, newName: String) {
-        viewModelScope.launch {
-            repository.updateDisplayName(id, newName.trim())
-            _events.emit(FileListEvent.RenameSuccess(newName.trim()))
+        fun toggleFileSelection(id: Long) {
+            val state = _uiState.value as? FileListUiState.Loaded ?: return
+            val newSelected =
+                if (id in state.selectedFileIds) {
+                    state.selectedFileIds - id
+                } else {
+                    state.selectedFileIds + id
+                }
+            _uiState.value = state.copy(selectedFileIds = newSelected)
         }
-    }
 
-    fun createPlaylist(name: String) {
-        viewModelScope.launch {
-            val id = playlistRepository.createPlaylist(name.trim())
-            _events.emit(FileListEvent.PlaylistCreated(name.trim(), id))
+        fun clearSelection() {
+            val state = _uiState.value as? FileListUiState.Loaded ?: return
+            _uiState.value = state.copy(selectedFileIds = emptySet())
         }
-    }
 
-    fun addFileToPlaylist(audioFileId: Long, playlistId: Long) {
-        viewModelScope.launch {
-            val file = repository.getById(audioFileId)
-            val playlist = playlistRepository.getById(playlistId)
-            playlistRepository.addFileToPlaylist(playlistId, audioFileId)
-            _events.emit(
-                FileListEvent.AddedToPlaylist(
-                    fileName = file?.displayName ?: "File",
-                    playlistName = playlist?.name ?: "Playlist",
+        fun addSelectedToPlaylist(playlistId: Long) {
+            val state = _uiState.value as? FileListUiState.Loaded ?: return
+            val selectedIds = state.selectedFileIds.toList()
+            if (selectedIds.isEmpty()) return
+            viewModelScope.launch {
+                val playlist = playlistRepository.getById(playlistId)
+                for (fileId in selectedIds) {
+                    playlistRepository.addFileToPlaylist(playlistId, fileId)
+                }
+                clearSelection()
+                _events.emit(
+                    FileListEvent.AddedBatchToPlaylist(
+                        count = selectedIds.size,
+                        playlistName = playlist?.name ?: "Playlist",
+                    ),
                 )
-            )
+            }
         }
-    }
 
-    fun playAll() {
-        val state = _uiState.value as? FileListUiState.Loaded ?: return
-        if (state.files.isEmpty()) return
-        val queueItems = state.files.map { file ->
-            QueueItem(
-                fileId = file.id,
-                displayName = file.displayName,
-                artist = file.artist,
-                durationMs = file.durationMs,
-                path = file.internalPath,
-            )
+        fun deleteFile(id: Long) {
+            viewModelScope.launch {
+                val file = repository.getById(id) ?: return@launch
+
+                try {
+                    File(file.internalPath).delete()
+                } catch (e: Exception) {
+                    Timber.w(e, "Failed to delete audio file: %s", file.internalPath)
+                }
+
+                try {
+                    val waveformDir = File(file.internalPath).parentFile?.parentFile
+                    waveformDir?.let {
+                        File(it, "waveforms/${file.id}.waveform").delete()
+                    }
+                } catch (e: Exception) {
+                    Timber.w(e, "Failed to delete waveform cache for id=%d", file.id)
+                }
+
+                repository.delete(id)
+                _events.emit(FileListEvent.DeleteSuccess(file.displayName))
+            }
         }
-        playbackManager.setQueue(queueItems)
+
+        fun renameFile(
+            id: Long,
+            newName: String,
+        ) {
+            viewModelScope.launch {
+                repository.updateDisplayName(id, newName.trim())
+                _events.emit(FileListEvent.RenameSuccess(newName.trim()))
+            }
+        }
+
+        fun createPlaylist(name: String) {
+            viewModelScope.launch {
+                val id = playlistRepository.createPlaylist(name.trim())
+                _events.emit(FileListEvent.PlaylistCreated(name.trim(), id))
+            }
+        }
+
+        fun addFileToPlaylist(
+            audioFileId: Long,
+            playlistId: Long,
+        ) {
+            viewModelScope.launch {
+                val file = repository.getById(audioFileId)
+                val playlist = playlistRepository.getById(playlistId)
+                playlistRepository.addFileToPlaylist(playlistId, audioFileId)
+                _events.emit(
+                    FileListEvent.AddedToPlaylist(
+                        fileName = file?.displayName ?: "File",
+                        playlistName = playlist?.name ?: "Playlist",
+                    ),
+                )
+            }
+        }
+
+        fun playAll() {
+            val state = _uiState.value as? FileListUiState.Loaded ?: return
+            if (state.files.isEmpty()) return
+            val queueItems =
+                state.files.map { file ->
+                    QueueItem(
+                        fileId = file.id,
+                        displayName = file.displayName,
+                        artist = file.artist,
+                        durationMs = file.durationMs,
+                        path = file.internalPath,
+                    )
+                }
+            playbackManager.setQueue(queueItems)
+        }
     }
-}

--- a/app/src/main/java/com/rehearsall/ui/navigation/MiniPlayerViewModel.kt
+++ b/app/src/main/java/com/rehearsall/ui/navigation/MiniPlayerViewModel.kt
@@ -22,51 +22,53 @@ data class MiniPlayerState(
 )
 
 @HiltViewModel
-class MiniPlayerViewModel @Inject constructor(
-    private val playbackManager: PlaybackManager,
-    private val repository: AudioFileRepository,
-) : ViewModel() {
+class MiniPlayerViewModel
+    @Inject
+    constructor(
+        private val playbackManager: PlaybackManager,
+        private val repository: AudioFileRepository,
+    ) : ViewModel() {
+        private val _state = MutableStateFlow(MiniPlayerState())
+        val state: StateFlow<MiniPlayerState> = _state.asStateFlow()
 
-    private val _state = MutableStateFlow(MiniPlayerState())
-    val state: StateFlow<MiniPlayerState> = _state.asStateFlow()
-
-    init {
-        viewModelScope.launch {
-            combine(
-                playbackManager.currentFileId,
-                playbackManager.playbackState,
-            ) { fileId, playback ->
-                Pair(fileId, playback)
-            }.collect { (fileId, playback) ->
-                if (fileId != null) {
-                    // Only look up the name if the file changed
-                    val name = if (fileId != _state.value.currentFileId) {
-                        repository.getById(fileId)?.displayName ?: "Unknown"
+        init {
+            viewModelScope.launch {
+                combine(
+                    playbackManager.currentFileId,
+                    playbackManager.playbackState,
+                ) { fileId, playback ->
+                    Pair(fileId, playback)
+                }.collect { (fileId, playback) ->
+                    if (fileId != null) {
+                        // Only look up the name if the file changed
+                        val name =
+                            if (fileId != _state.value.currentFileId) {
+                                repository.getById(fileId)?.displayName ?: "Unknown"
+                            } else {
+                                _state.value.trackName
+                            }
+                        _state.update {
+                            it.copy(
+                                isVisible = true,
+                                trackName = name,
+                                currentFileId = fileId,
+                                playbackState = playback,
+                            )
+                        }
                     } else {
-                        _state.value.trackName
-                    }
-                    _state.update {
-                        it.copy(
-                            isVisible = true,
-                            trackName = name,
-                            currentFileId = fileId,
-                            playbackState = playback,
-                        )
-                    }
-                } else {
-                    _state.update {
-                        it.copy(isVisible = false, currentFileId = null)
+                        _state.update {
+                            it.copy(isVisible = false, currentFileId = null)
+                        }
                     }
                 }
             }
         }
-    }
 
-    fun togglePlayPause() {
-        if (_state.value.playbackState.isPlaying) {
-            playbackManager.pause()
-        } else {
-            playbackManager.play()
+        fun togglePlayPause() {
+            if (_state.value.playbackState.isPlaying) {
+                playbackManager.pause()
+            } else {
+                playbackManager.play()
+            }
         }
     }
-}

--- a/app/src/main/java/com/rehearsall/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/rehearsall/ui/navigation/NavGraph.kt
@@ -3,14 +3,12 @@ package com.rehearsall.ui.navigation
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -27,9 +25,7 @@ import com.rehearsall.ui.playlist.PlaylistScreen
 import com.rehearsall.ui.settings.SettingsScreen
 
 @Composable
-fun RehearsAllNavGraph(
-    windowSizeClass: WindowSizeClass,
-) {
+fun RehearsAllNavGraph(windowSizeClass: WindowSizeClass) {
     val navController = rememberNavController()
 
     // MiniPlayer needs playback state — use a shared ViewModel scoped to the nav graph
@@ -37,8 +33,9 @@ fun RehearsAllNavGraph(
     val miniPlayerState by miniPlayerViewModel.state.collectAsStateWithLifecycle()
 
     // Hide MiniPlayer on the Playback screen (already showing full controls)
-    val currentRoute = navController.currentBackStackEntryAsState().value
-        ?.destination?.route
+    val currentRoute =
+        navController.currentBackStackEntryAsState().value
+            ?.destination?.route
     val showMiniPlayer = miniPlayerState.isVisible && currentRoute != Screen.Playback.route
 
     Scaffold(
@@ -61,9 +58,10 @@ fun RehearsAllNavGraph(
         NavHost(
             navController = navController,
             startDestination = Screen.FileList.route,
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding),
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
         ) {
             composable(Screen.FileList.route) {
                 FileListScreen(
@@ -81,9 +79,10 @@ fun RehearsAllNavGraph(
 
             composable(
                 route = Screen.Playback.route,
-                arguments = listOf(
-                    navArgument("audioFileId") { type = NavType.LongType }
-                ),
+                arguments =
+                    listOf(
+                        navArgument("audioFileId") { type = NavType.LongType },
+                    ),
                 enterTransition = { fadeIn(animationSpec = tween(150)) },
                 exitTransition = { fadeOut(animationSpec = tween(150)) },
                 popEnterTransition = { fadeIn(animationSpec = tween(150)) },
@@ -103,9 +102,10 @@ fun RehearsAllNavGraph(
 
             composable(
                 route = Screen.Playlist.route,
-                arguments = listOf(
-                    navArgument("playlistId") { type = NavType.LongType }
-                ),
+                arguments =
+                    listOf(
+                        navArgument("playlistId") { type = NavType.LongType },
+                    ),
             ) {
                 PlaylistScreen(
                     onNavigateBack = { navController.popBackStack() },

--- a/app/src/main/java/com/rehearsall/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/rehearsall/ui/navigation/Screen.kt
@@ -5,11 +5,14 @@ package com.rehearsall.ui.navigation
  */
 sealed class Screen(val route: String) {
     data object FileList : Screen("file_list")
+
     data object Playback : Screen("playback/{audioFileId}") {
         fun createRoute(audioFileId: Long) = "playback/$audioFileId"
     }
+
     data object Playlist : Screen("playlist/{playlistId}") {
         fun createRoute(playlistId: Long) = "playlist/$playlistId"
     }
+
     data object Settings : Screen("settings")
 }

--- a/app/src/main/java/com/rehearsall/ui/playback/PlaybackScreen.kt
+++ b/app/src/main/java/com/rehearsall/ui/playback/PlaybackScreen.kt
@@ -4,35 +4,36 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.QueueMusic
-import androidx.compose.material.icons.filled.Bookmarks
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Remove
-import androidx.compose.material.icons.filled.Speed
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.QueueMusic
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Bookmarks
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Remove
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Speed
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -49,18 +50,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.compose.ui.draw.clip
 import com.rehearsall.data.repository.WaveformState
 import com.rehearsall.domain.model.ChunkMarker
 import com.rehearsall.domain.model.Loop
@@ -87,8 +87,9 @@ fun PlaybackScreen(
     var showExitConfirmation by remember { mutableStateOf(false) }
 
     // Predictive back: confirm if practice session is active
-    val isPracticing = uiState.practiceState is PracticeState.Playing
-            || uiState.practiceState is PracticeState.Pausing
+    val isPracticing =
+        uiState.practiceState is PracticeState.Playing ||
+            uiState.practiceState is PracticeState.Pausing
     BackHandler(enabled = isPracticing) {
         showExitConfirmation = true
     }
@@ -104,10 +105,11 @@ fun PlaybackScreen(
     LaunchedEffect(uiState.errorMessage) {
         val message = uiState.errorMessage ?: return@LaunchedEffect
         if (uiState.fileNotFound) {
-            val result = snackbarHostState.showSnackbar(
-                message = message,
-                actionLabel = "Remove",
-            )
+            val result =
+                snackbarHostState.showSnackbar(
+                    message = message,
+                    actionLabel = "Remove",
+                )
             if (result == SnackbarResult.ActionPerformed) {
                 viewModel.removeDeletedFile()
                 onNavigateBack()
@@ -177,9 +179,10 @@ fun PlaybackScreen(
         when {
             uiState.isLoading -> {
                 Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(innerPadding),
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding),
                     contentAlignment = Alignment.Center,
                 ) {
                     CircularProgressIndicator()
@@ -188,9 +191,10 @@ fun PlaybackScreen(
 
             uiState.fileNotFound -> {
                 Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(innerPadding),
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding),
                     contentAlignment = Alignment.Center,
                 ) {
                     Text(
@@ -206,10 +210,11 @@ fun PlaybackScreen(
                 PlaybackContent(
                     uiState = uiState,
                     viewModel = viewModel,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(innerPadding)
-                        .padding(horizontal = 24.dp),
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding)
+                            .padding(horizontal = 24.dp),
                 )
             }
         }
@@ -302,9 +307,10 @@ private fun PlaybackContent(
     ) {
         // Track info + overlay area
         Box(
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth(),
+            modifier =
+                Modifier
+                    .weight(1f)
+                    .fillMaxWidth(),
             contentAlignment = Alignment.Center,
         ) {
             // Default: track info centered
@@ -328,43 +334,47 @@ private fun PlaybackContent(
 
             // Overlay: saved loops or chunks list with dismiss button
             when (uiState.overlayMode) {
-                OverlayMode.LOOPS -> if (uiState.savedLoops.isNotEmpty()) {
-                    OverlayList(
-                        title = "Saved Loops",
-                        onDismiss = viewModel::dismissWaveform,
-                        modifier = Modifier
-                            .fillMaxWidth(0.5f)
-                            .fillMaxHeight(0.5f)
-                            .align(Alignment.TopStart),
-                    ) {
-                        items(uiState.savedLoops, key = { it.id }) { loop ->
-                            OverlayLoopRow(
-                                loop = loop,
-                                onTap = {
-                                    viewModel.loadLoop(loop)
-                                },
-                            )
+                OverlayMode.LOOPS ->
+                    if (uiState.savedLoops.isNotEmpty()) {
+                        OverlayList(
+                            title = "Saved Loops",
+                            onDismiss = viewModel::dismissWaveform,
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth(0.5f)
+                                    .fillMaxHeight(0.5f)
+                                    .align(Alignment.TopStart),
+                        ) {
+                            items(uiState.savedLoops, key = { it.id }) { loop ->
+                                OverlayLoopRow(
+                                    loop = loop,
+                                    onTap = {
+                                        viewModel.loadLoop(loop)
+                                    },
+                                )
+                            }
                         }
                     }
-                }
-                OverlayMode.CHUNKS -> if (uiState.chunkMarkers.isNotEmpty()) {
-                    OverlayList(
-                        title = "Chunk Markers",
-                        onDismiss = viewModel::dismissWaveform,
-                        modifier = Modifier
-                            .fillMaxWidth(0.5f)
-                            .fillMaxHeight(0.5f)
-                            .align(Alignment.TopStart),
-                    ) {
-                        items(uiState.chunkMarkers, key = { it.id }) { marker ->
-                            OverlayChunkRow(
-                                marker = marker,
-                                durationMs = uiState.playbackState.durationMs,
-                                onTap = { viewModel.seekToChunk(marker.positionMs) },
-                            )
+                OverlayMode.CHUNKS ->
+                    if (uiState.chunkMarkers.isNotEmpty()) {
+                        OverlayList(
+                            title = "Chunk Markers",
+                            onDismiss = viewModel::dismissWaveform,
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth(0.5f)
+                                    .fillMaxHeight(0.5f)
+                                    .align(Alignment.TopStart),
+                        ) {
+                            items(uiState.chunkMarkers, key = { it.id }) { marker ->
+                                OverlayChunkRow(
+                                    marker = marker,
+                                    durationMs = uiState.playbackState.durationMs,
+                                    onTap = { viewModel.seekToChunk(marker.positionMs) },
+                                )
+                            }
                         }
                     }
-                }
                 OverlayMode.NONE -> { /* show track info only */ }
             }
         }
@@ -377,27 +387,42 @@ private fun PlaybackContent(
         if (uiState.showWaveform && waveform is WaveformState.Ready && duration > 1L) {
             val positionFraction = playback.positionMs.toFloat() / duration.toFloat()
 
-            val loopStartFrac = if (overlayMode == OverlayMode.LOOPS) {
-                uiState.activeLoop?.let {
-                    if (it.endMs > it.startMs) it.startMs.toFloat() / duration else null
+            val loopStartFrac =
+                if (overlayMode == OverlayMode.LOOPS) {
+                    uiState.activeLoop?.let {
+                        if (it.endMs > it.startMs) it.startMs.toFloat() / duration else null
+                    }
+                } else {
+                    null
                 }
-            } else null
-            val loopEndFrac = if (overlayMode == OverlayMode.LOOPS) {
-                uiState.activeLoop?.let {
-                    if (it.endMs > it.startMs) it.endMs.toFloat() / duration else null
+            val loopEndFrac =
+                if (overlayMode == OverlayMode.LOOPS) {
+                    uiState.activeLoop?.let {
+                        if (it.endMs > it.startMs) it.endMs.toFloat() / duration else null
+                    }
+                } else {
+                    null
                 }
-            } else null
 
-            val chunkFractions = if (overlayMode == OverlayMode.CHUNKS) {
-                uiState.chunkMarkers.map { it.positionMs.toFloat() / duration }
-            } else emptyList()
+            val chunkFractions =
+                if (overlayMode == OverlayMode.CHUNKS) {
+                    uiState.chunkMarkers.map { it.positionMs.toFloat() / duration }
+                } else {
+                    emptyList()
+                }
             val practiceStep = (uiState.practiceState as? PracticeState.Playing)?.currentStep
-            val activeChunkStart = if (overlayMode == OverlayMode.CHUNKS) {
-                practiceStep?.let { it.startMs.toFloat() / duration }
-            } else null
-            val activeChunkEnd = if (overlayMode == OverlayMode.CHUNKS) {
-                practiceStep?.let { it.endMs.toFloat() / duration }
-            } else null
+            val activeChunkStart =
+                if (overlayMode == OverlayMode.CHUNKS) {
+                    practiceStep?.let { it.startMs.toFloat() / duration }
+                } else {
+                    null
+                }
+            val activeChunkEnd =
+                if (overlayMode == OverlayMode.CHUNKS) {
+                    practiceStep?.let { it.endMs.toFloat() / duration }
+                } else {
+                    null
+                }
 
             var wfZoom by remember { mutableFloatStateOf(1f) }
             var wfScroll by remember { mutableFloatStateOf(0f) }
@@ -550,11 +575,12 @@ private fun OverlayList(
     content: LazyListScope.() -> Unit,
 ) {
     Column(
-        modifier = modifier
-            .padding(start = 4.dp, top = 4.dp)
-            .clip(RoundedCornerShape(12.dp))
-            .background(MaterialTheme.colorScheme.surfaceContainerLow.copy(alpha = 0.85f))
-            .padding(8.dp),
+        modifier =
+            modifier
+                .padding(start = 4.dp, top = 4.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(MaterialTheme.colorScheme.surfaceContainerLow.copy(alpha = 0.85f))
+                .padding(8.dp),
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -581,9 +607,10 @@ private fun OverlayList(
         }
         Spacer(modifier = Modifier.height(4.dp))
         LazyColumn(
-            modifier = Modifier
-                .fillMaxWidth()
-                .horizontalScroll(rememberScrollState()),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState()),
             verticalArrangement = Arrangement.spacedBy(0.dp),
             content = content,
         )
@@ -596,9 +623,10 @@ private fun OverlayLoopRow(
     onTap: () -> Unit,
 ) {
     Column(
-        modifier = Modifier
-            .clickable(onClick = onTap)
-            .padding(horizontal = 4.dp, vertical = 4.dp),
+        modifier =
+            Modifier
+                .clickable(onClick = onTap)
+                .padding(horizontal = 4.dp, vertical = 4.dp),
     ) {
         Text(
             text = loop.name,
@@ -625,8 +653,9 @@ private fun OverlayChunkRow(
         text = formatDuration(marker.positionMs),
         style = MaterialTheme.typography.bodySmall,
         softWrap = false,
-        modifier = Modifier
-            .clickable(onClick = onTap)
-            .padding(horizontal = 4.dp, vertical = 4.dp),
+        modifier =
+            Modifier
+                .clickable(onClick = onTap)
+                .padding(horizontal = 4.dp, vertical = 4.dp),
     )
 }

--- a/app/src/main/java/com/rehearsall/ui/playback/PlaybackViewModel.kt
+++ b/app/src/main/java/com/rehearsall/ui/playback/PlaybackViewModel.kt
@@ -14,7 +14,6 @@ import com.rehearsall.domain.model.Loop
 import com.rehearsall.domain.model.OverlayMode
 import com.rehearsall.domain.model.PracticeMode
 import com.rehearsall.domain.model.PracticeSettings
-import java.io.File
 import com.rehearsall.domain.usecase.GeneratePracticeStepsUseCase
 import com.rehearsall.playback.ChunkedPracticeEngine
 import com.rehearsall.playback.LoopRegion
@@ -33,553 +32,582 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import java.io.File
 import javax.inject.Inject
 
 @HiltViewModel
-class PlaybackViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle,
-    private val playbackManager: PlaybackManager,
-    private val repository: AudioFileRepository,
-    private val waveformRepository: WaveformRepository,
-    private val bookmarkRepository: BookmarkRepository,
-    private val loopRepository: LoopRepository,
-    private val chunkMarkerRepository: ChunkMarkerRepository,
-    private val practiceSettingsRepository: PracticeSettingsRepository,
-    private val practiceEngine: ChunkedPracticeEngine,
-    private val userPreferencesRepository: UserPreferencesRepository,
-) : ViewModel() {
+class PlaybackViewModel
+    @Inject
+    constructor(
+        savedStateHandle: SavedStateHandle,
+        private val playbackManager: PlaybackManager,
+        private val repository: AudioFileRepository,
+        private val waveformRepository: WaveformRepository,
+        private val bookmarkRepository: BookmarkRepository,
+        private val loopRepository: LoopRepository,
+        private val chunkMarkerRepository: ChunkMarkerRepository,
+        private val practiceSettingsRepository: PracticeSettingsRepository,
+        private val practiceEngine: ChunkedPracticeEngine,
+        private val userPreferencesRepository: UserPreferencesRepository,
+    ) : ViewModel() {
+        private val audioFileId: Long =
+            savedStateHandle["audioFileId"]
+                ?: throw IllegalArgumentException("audioFileId required")
 
-    private val audioFileId: Long = savedStateHandle["audioFileId"]
-        ?: throw IllegalArgumentException("audioFileId required")
+        private val _uiState = MutableStateFlow(PlaybackUiState())
+        val uiState: StateFlow<PlaybackUiState> = _uiState.asStateFlow()
 
-    private val _uiState = MutableStateFlow(PlaybackUiState())
-    val uiState: StateFlow<PlaybackUiState> = _uiState.asStateFlow()
+        // Emits a file ID when skip-to-next/previous transitions to a different track
+        private val _navigationEvent = MutableSharedFlow<Long>(extraBufferCapacity = 1)
+        val navigationEvent: SharedFlow<Long> = _navigationEvent.asSharedFlow()
 
-    // Emits a file ID when skip-to-next/previous transitions to a different track
-    private val _navigationEvent = MutableSharedFlow<Long>(extraBufferCapacity = 1)
-    val navigationEvent: SharedFlow<Long> = _navigationEvent.asSharedFlow()
+        private val skipIncrementMs: StateFlow<Long> =
+            userPreferencesRepository.skipIncrementMs
+                .stateIn(viewModelScope, SharingStarted.Eagerly, 5000L)
 
-    private val skipIncrementMs: StateFlow<Long> = userPreferencesRepository.skipIncrementMs
-        .stateIn(viewModelScope, SharingStarted.Eagerly, 5000L)
+        init {
+            loadFile()
+            observePlaybackState()
+            observeCurrentFileId()
+            observeBookmarks()
+            observeLoops()
+            observeLoopRegion()
+            observeChunkMarkers()
+            observePracticeState()
+            loadPracticeSettings()
+            observeSkipIncrement()
+            observeOverlayMode()
+        }
 
-    init {
-        loadFile()
-        observePlaybackState()
-        observeCurrentFileId()
-        observeBookmarks()
-        observeLoops()
-        observeLoopRegion()
-        observeChunkMarkers()
-        observePracticeState()
-        loadPracticeSettings()
-        observeSkipIncrement()
-        observeOverlayMode()
-    }
-
-    private fun loadFile() {
-        viewModelScope.launch {
-            val file = repository.getById(audioFileId)
-            if (file == null) {
-                Timber.w("Audio file not found in database: id=%d", audioFileId)
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        fileName = "File not found",
-                        fileNotFound = true,
-                        errorMessage = "This file no longer exists",
-                    )
+        private fun loadFile() {
+            viewModelScope.launch {
+                val file = repository.getById(audioFileId)
+                if (file == null) {
+                    Timber.w("Audio file not found in database: id=%d", audioFileId)
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            fileName = "File not found",
+                            fileNotFound = true,
+                            errorMessage = "This file no longer exists",
+                        )
+                    }
+                    return@launch
                 }
-                return@launch
-            }
 
-            // Verify the audio file still exists on disk
-            if (!File(file.internalPath).exists()) {
-                Timber.w("Audio file missing from disk: id=%d path=%s", audioFileId, file.internalPath)
+                // Verify the audio file still exists on disk
+                if (!File(file.internalPath).exists()) {
+                    Timber.w("Audio file missing from disk: id=%d path=%s", audioFileId, file.internalPath)
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            fileName = file.displayName,
+                            fileNotFound = true,
+                            errorMessage = "Audio file was deleted externally. Remove from library?",
+                        )
+                    }
+                    return@launch
+                }
+
                 _uiState.update {
                     it.copy(
                         isLoading = false,
                         fileName = file.displayName,
-                        fileNotFound = true,
-                        errorMessage = "Audio file was deleted externally. Remove from library?",
+                        artist = file.artist,
                     )
                 }
-                return@launch
-            }
 
-            _uiState.update {
-                it.copy(
-                    isLoading = false,
-                    fileName = file.displayName,
-                    artist = file.artist,
+                // Load waveform
+                loadWaveform(audioFileId, file.internalPath)
+
+                // Only start playback if this file isn't already playing
+                if (playbackManager.currentFileId.value != audioFileId) {
+                    playbackManager.playFile(
+                        fileId = audioFileId,
+                        path = file.internalPath,
+                        startPositionMs = file.lastPositionMs,
+                    )
+                    if (file.lastSpeed != 1.0f) {
+                        playbackManager.setSpeed(file.lastSpeed)
+                    }
+                }
+            }
+        }
+
+        fun removeDeletedFile() {
+            viewModelScope.launch {
+                repository.delete(audioFileId)
+                Timber.i("Removed missing file from library: id=%d", audioFileId)
+            }
+        }
+
+        fun clearError() {
+            _uiState.update { it.copy(errorMessage = null) }
+        }
+
+        // When ExoPlayer transitions to a different track (skip-to-next/previous in a queue),
+        // emit a navigation event so the screen can replace itself with the new file's screen.
+        private fun observeCurrentFileId() {
+            viewModelScope.launch {
+                playbackManager.currentFileId.collect { fileId ->
+                    if (fileId != null && fileId != audioFileId) {
+                        _navigationEvent.tryEmit(fileId)
+                    }
+                }
+            }
+        }
+
+        private fun observeSkipIncrement() {
+            viewModelScope.launch {
+                skipIncrementMs.collect { ms ->
+                    _uiState.update { it.copy(skipIncrementMs = ms) }
+                }
+            }
+        }
+
+        private fun observeOverlayMode() {
+            viewModelScope.launch {
+                userPreferencesRepository.waveformOverlay.collect { mode ->
+                    _uiState.update { it.copy(overlayMode = mode) }
+                }
+            }
+        }
+
+        private fun loadWaveform(
+            fileId: Long,
+            filePath: String,
+        ) {
+            viewModelScope.launch {
+                waveformRepository.getWaveform(fileId, filePath).collect { waveformState ->
+                    _uiState.update { it.copy(waveformState = waveformState) }
+                }
+            }
+        }
+
+        private fun observePlaybackState() {
+            viewModelScope.launch {
+                combine(
+                    playbackManager.playbackState,
+                    playbackManager.repeatMode,
+                    playbackManager.shuffleEnabled,
+                    playbackManager.currentQueue,
+                ) { playback, repeat, shuffle, queue ->
+                    PlaybackCombined(playback, repeat, shuffle, queue)
+                }.collect { combined ->
+                    _uiState.update {
+                        it.copy(
+                            playbackState = combined.playback,
+                            repeatMode = combined.repeat,
+                            shuffleEnabled = combined.shuffle,
+                            queue = combined.queue,
+                        )
+                    }
+                }
+            }
+        }
+
+        private data class PlaybackCombined(
+            val playback: com.rehearsall.playback.PlaybackState,
+            val repeat: RepeatMode,
+            val shuffle: Boolean,
+            val queue: List<com.rehearsall.domain.model.QueueItem>,
+        )
+
+        // -- Transport controls --
+
+        fun togglePlayPause() {
+            if (_uiState.value.playbackState.isPlaying) {
+                playbackManager.pause()
+            } else {
+                playbackManager.play()
+            }
+        }
+
+        fun seekTo(positionMs: Long) {
+            playbackManager.seekTo(positionMs)
+        }
+
+        fun skipForward() {
+            playbackManager.skipForward(skipIncrementMs.value)
+        }
+
+        fun skipBackward() {
+            playbackManager.skipBackward(skipIncrementMs.value)
+        }
+
+        fun skipToNext() {
+            playbackManager.skipToNext()
+        }
+
+        fun skipToPrevious() {
+            playbackManager.skipToPrevious()
+        }
+
+        // -- Repeat & shuffle --
+
+        fun cycleRepeatMode() {
+            val next = _uiState.value.repeatMode.next()
+            playbackManager.setRepeatMode(next)
+        }
+
+        fun toggleShuffle() {
+            playbackManager.setShuffleEnabled(!_uiState.value.shuffleEnabled)
+        }
+
+        // -- Speed --
+
+        fun setSpeed(speed: Float) {
+            playbackManager.setSpeed(speed)
+        }
+
+        fun toggleSpeedSheet() {
+            _uiState.update { it.copy(showSpeedSheet = !it.showSpeedSheet) }
+        }
+
+        fun dismissSpeedSheet() {
+            _uiState.update { it.copy(showSpeedSheet = false) }
+        }
+
+        // -- Queue --
+
+        fun toggleQueueSheet() {
+            _uiState.update { it.copy(showQueueSheet = !it.showQueueSheet) }
+        }
+
+        fun dismissQueueSheet() {
+            _uiState.update { it.copy(showQueueSheet = false) }
+        }
+
+        fun skipToQueueItem(index: Int) {
+            playbackManager.skipToQueueItem(index)
+        }
+
+        fun removeFromQueue(index: Int) {
+            playbackManager.removeFromQueue(index)
+        }
+
+        fun clearQueue() {
+            playbackManager.clearQueue()
+        }
+
+        // -- Bookmarks --
+
+        private fun observeBookmarks() {
+            viewModelScope.launch {
+                bookmarkRepository.getBookmarksForFile(audioFileId).collect { bookmarks ->
+                    _uiState.update { it.copy(bookmarks = bookmarks) }
+                }
+            }
+        }
+
+        fun toggleMarkersSheet() {
+            _uiState.update { it.copy(showMarkersSheet = !it.showMarkersSheet) }
+        }
+
+        fun dismissMarkersSheet() {
+            _uiState.update { it.copy(showMarkersSheet = false) }
+        }
+
+        fun addBookmark() {
+            val positionMs = _uiState.value.playbackState.positionMs
+            val count = _uiState.value.bookmarks.size + 1
+            viewModelScope.launch {
+                bookmarkRepository.addBookmark(
+                    audioFileId = audioFileId,
+                    positionMs = positionMs,
+                    name = "Bookmark $count",
                 )
             }
+        }
 
-            // Load waveform
-            loadWaveform(audioFileId, file.internalPath)
+        fun renameBookmark(
+            id: Long,
+            name: String,
+        ) {
+            viewModelScope.launch {
+                bookmarkRepository.renameBookmark(id, name)
+            }
+        }
 
-            // Only start playback if this file isn't already playing
-            if (playbackManager.currentFileId.value != audioFileId) {
-                playbackManager.playFile(
-                    fileId = audioFileId,
-                    path = file.internalPath,
-                    startPositionMs = file.lastPositionMs,
+        fun updateBookmarkPosition(
+            id: Long,
+            positionMs: Long,
+        ) {
+            viewModelScope.launch {
+                bookmarkRepository.updateBookmarkPosition(id, positionMs)
+            }
+        }
+
+        fun deleteBookmark(id: Long) {
+            viewModelScope.launch {
+                bookmarkRepository.deleteBookmark(id)
+            }
+        }
+
+        fun seekToBookmark(positionMs: Long) {
+            playbackManager.seekTo(positionMs)
+        }
+
+        // -- A-B Loops --
+
+        private fun observeLoops() {
+            viewModelScope.launch {
+                loopRepository.getLoopsForFile(audioFileId).collect { loops ->
+                    _uiState.update { it.copy(savedLoops = loops) }
+                }
+            }
+        }
+
+        private fun observeLoopRegion() {
+            viewModelScope.launch {
+                playbackManager.loopRegion.collect { region ->
+                    _uiState.update { state ->
+                        state.copy(
+                            activeLoop = region,
+                            // Auto-show the loops overlay when a loop is activated; auto-hide when cleared.
+                            overlayMode =
+                                when {
+                                    region != null -> OverlayMode.LOOPS
+                                    state.overlayMode == OverlayMode.LOOPS -> OverlayMode.NONE
+                                    else -> state.overlayMode
+                                },
+                        )
+                    }
+                }
+            }
+        }
+
+        fun dismissWaveform() {
+            playbackManager.clearLoopRegion()
+            _uiState.update { it.copy(overlayMode = OverlayMode.NONE) }
+            viewModelScope.launch {
+                userPreferencesRepository.setWaveformOverlay(OverlayMode.NONE)
+            }
+        }
+
+        fun setLoopA() {
+            val positionMs = _uiState.value.playbackState.positionMs
+            val current = _uiState.value.activeLoop
+            if (current != null && positionMs < current.endMs - 100) {
+                playbackManager.setLoopRegion(LoopRegion(positionMs, current.endMs))
+            } else {
+                // Store A temporarily — we'll set the full region when B is set
+                _uiState.update { it.copy(activeLoop = LoopRegion(positionMs, positionMs)) }
+            }
+        }
+
+        fun setLoopB() {
+            val positionMs = _uiState.value.playbackState.positionMs
+            val current = _uiState.value.activeLoop
+            val startMs = current?.startMs ?: 0L
+            if (positionMs > startMs + 100) {
+                playbackManager.setLoopRegion(LoopRegion(startMs, positionMs))
+            }
+        }
+
+        fun createLoop(
+            startMs: Long,
+            endMs: Long,
+        ) {
+            if (endMs - startMs >= 100) {
+                playbackManager.setLoopRegion(LoopRegion(startMs, endMs))
+            }
+        }
+
+        fun clearLoop() {
+            playbackManager.clearLoopRegion()
+        }
+
+        fun saveLoop(name: String) {
+            val region = _uiState.value.activeLoop ?: return
+            viewModelScope.launch {
+                loopRepository.saveLoop(
+                    audioFileId = audioFileId,
+                    name = name,
+                    startMs = region.startMs,
+                    endMs = region.endMs,
                 )
-                if (file.lastSpeed != 1.0f) {
-                    playbackManager.setSpeed(file.lastSpeed)
+            }
+        }
+
+        fun loadLoop(loop: Loop) {
+            playbackManager.setLoopRegion(LoopRegion(loop.startMs, loop.endMs))
+            playbackManager.seekTo(loop.startMs)
+        }
+
+        fun deleteLoop(id: Long) {
+            viewModelScope.launch {
+                loopRepository.deleteLoop(id)
+            }
+        }
+
+        fun updateLoopBounds(loopId: Long) {
+            val region = _uiState.value.activeLoop ?: return
+            viewModelScope.launch {
+                loopRepository.updateBounds(loopId, region.startMs, region.endMs)
+            }
+        }
+
+        fun adjustLoopBoundary(
+            isStart: Boolean,
+            newMs: Long,
+        ) {
+            val current = _uiState.value.activeLoop ?: return
+            val updated =
+                if (isStart) {
+                    var start = newMs.coerceAtLeast(0)
+                    // Don't let begin go past current playback position
+                    val pos = _uiState.value.playbackState.positionMs
+                    if (pos > current.startMs) {
+                        start = start.coerceAtMost(pos)
+                    }
+                    LoopRegion(start, current.endMs)
+                } else {
+                    LoopRegion(current.startMs, newMs.coerceAtMost(_uiState.value.playbackState.durationMs))
+                }
+            if (updated.endMs - updated.startMs >= 100) {
+                playbackManager.setLoopRegion(updated)
+            }
+        }
+
+        // -- Chunks & Practice --
+
+        private fun observeChunkMarkers() {
+            viewModelScope.launch {
+                chunkMarkerRepository.getMarkersForFile(audioFileId).collect { markers ->
+                    _uiState.update { it.copy(chunkMarkers = markers) }
                 }
             }
         }
-    }
 
-    fun removeDeletedFile() {
-        viewModelScope.launch {
-            repository.delete(audioFileId)
-            Timber.i("Removed missing file from library: id=%d", audioFileId)
-        }
-    }
-
-    fun clearError() {
-        _uiState.update { it.copy(errorMessage = null) }
-    }
-
-    // When ExoPlayer transitions to a different track (skip-to-next/previous in a queue),
-    // emit a navigation event so the screen can replace itself with the new file's screen.
-    private fun observeCurrentFileId() {
-        viewModelScope.launch {
-            playbackManager.currentFileId.collect { fileId ->
-                if (fileId != null && fileId != audioFileId) {
-                    _navigationEvent.tryEmit(fileId)
+        private fun observePracticeState() {
+            viewModelScope.launch {
+                practiceEngine.state.collect { state ->
+                    _uiState.update { it.copy(practiceState = state) }
                 }
             }
         }
-    }
 
-    private fun observeSkipIncrement() {
-        viewModelScope.launch {
-            skipIncrementMs.collect { ms ->
-                _uiState.update { it.copy(skipIncrementMs = ms) }
+        private fun loadPracticeSettings() {
+            viewModelScope.launch {
+                val settings = practiceSettingsRepository.getForFile(audioFileId)
+                _uiState.update { it.copy(practiceSettings = settings) }
             }
         }
-    }
 
-    private fun observeOverlayMode() {
-        viewModelScope.launch {
-            userPreferencesRepository.waveformOverlay.collect { mode ->
-                _uiState.update { it.copy(overlayMode = mode) }
+        fun addChunkMarker() {
+            val positionMs = _uiState.value.playbackState.positionMs
+            val count = _uiState.value.chunkMarkers.size + 1
+            viewModelScope.launch {
+                chunkMarkerRepository.addMarker(
+                    audioFileId = audioFileId,
+                    positionMs = positionMs,
+                    label = "Marker $count",
+                )
             }
         }
-    }
 
-    private fun loadWaveform(fileId: Long, filePath: String) {
-        viewModelScope.launch {
-            waveformRepository.getWaveform(fileId, filePath).collect { waveformState ->
-                _uiState.update { it.copy(waveformState = waveformState) }
+        fun updateChunkMarkerPosition(
+            id: Long,
+            positionMs: Long,
+        ) {
+            viewModelScope.launch {
+                chunkMarkerRepository.updatePosition(id, positionMs)
             }
         }
-    }
 
-    private fun observePlaybackState() {
-        viewModelScope.launch {
-            combine(
-                playbackManager.playbackState,
-                playbackManager.repeatMode,
-                playbackManager.shuffleEnabled,
-                playbackManager.currentQueue,
-            ) { playback, repeat, shuffle, queue ->
-                PlaybackCombined(playback, repeat, shuffle, queue)
-            }.collect { combined ->
-                _uiState.update {
-                    it.copy(
-                        playbackState = combined.playback,
-                        repeatMode = combined.repeat,
-                        shuffleEnabled = combined.shuffle,
-                        queue = combined.queue,
-                    )
+        fun deleteChunkMarker(id: Long) {
+            viewModelScope.launch {
+                chunkMarkerRepository.deleteMarker(id)
+            }
+        }
+
+        fun seekToChunk(positionMs: Long) {
+            playbackManager.seekTo(positionMs)
+        }
+
+        fun togglePracticeSheet() {
+            _uiState.update { it.copy(showPracticeSheet = !it.showPracticeSheet) }
+        }
+
+        fun dismissPracticeSheet() {
+            _uiState.update { it.copy(showPracticeSheet = false) }
+        }
+
+        fun updatePracticeMode(mode: PracticeMode) {
+            val updated = _uiState.value.practiceSettings.copy(mode = mode)
+            _uiState.update { it.copy(practiceSettings = updated) }
+            savePracticeSettings(updated)
+        }
+
+        fun updateRepeatCount(count: Int) {
+            val updated = _uiState.value.practiceSettings.copy(repeatCount = count)
+            _uiState.update { it.copy(practiceSettings = updated) }
+            savePracticeSettings(updated)
+        }
+
+        fun updateGapBetweenReps(ms: Long) {
+            val updated = _uiState.value.practiceSettings.copy(gapBetweenRepsMs = ms)
+            _uiState.update { it.copy(practiceSettings = updated) }
+            savePracticeSettings(updated)
+        }
+
+        fun updateGapBetweenChunks(ms: Long) {
+            val updated = _uiState.value.practiceSettings.copy(gapBetweenChunksMs = ms)
+            _uiState.update { it.copy(practiceSettings = updated) }
+            savePracticeSettings(updated)
+        }
+
+        private fun savePracticeSettings(settings: PracticeSettings) {
+            viewModelScope.launch {
+                practiceSettingsRepository.save(audioFileId, settings)
+            }
+        }
+
+        fun startPractice() {
+            val markers = _uiState.value.chunkMarkers
+            val settings = _uiState.value.practiceSettings
+            val durationMs = _uiState.value.playbackState.durationMs
+
+            val steps =
+                when (settings.mode) {
+                    PracticeMode.SINGLE_CHUNK_LOOP ->
+                        GeneratePracticeStepsUseCase.generateSingleChunkSteps(markers, durationMs, settings.repeatCount)
+                    PracticeMode.CUMULATIVE_BUILD_UP ->
+                        GeneratePracticeStepsUseCase.generateCumulativeBuildUpSteps(markers, durationMs, settings.repeatCount)
+                    PracticeMode.SEQUENTIAL_PLAY ->
+                        GeneratePracticeStepsUseCase.generateSequentialSteps(markers, durationMs)
                 }
+
+            practiceEngine.startPractice(steps, settings, viewModelScope)
+        }
+
+        fun stopPractice() {
+            practiceEngine.stopPractice()
+        }
+
+        fun practiceSkipNext() {
+            practiceEngine.skipToNextStep()
+        }
+
+        fun practiceSkipPrevious() {
+            practiceEngine.skipToPreviousStep()
+        }
+
+        // -- Lifecycle: save position & speed when leaving --
+
+        override fun onCleared() {
+            super.onCleared()
+            val state = _uiState.value.playbackState
+            viewModelScope.launch {
+                repository.updateLastPlayed(audioFileId, state.positionMs)
+                repository.updateLastSpeed(audioFileId, state.speed)
+                Timber.d(
+                    "Saved playback state for id=%d: pos=%dms, speed=%.2fx",
+                    audioFileId,
+                    state.positionMs,
+                    state.speed,
+                )
             }
         }
     }
-
-    private data class PlaybackCombined(
-        val playback: com.rehearsall.playback.PlaybackState,
-        val repeat: RepeatMode,
-        val shuffle: Boolean,
-        val queue: List<com.rehearsall.domain.model.QueueItem>,
-    )
-
-    // -- Transport controls --
-
-    fun togglePlayPause() {
-        if (_uiState.value.playbackState.isPlaying) {
-            playbackManager.pause()
-        } else {
-            playbackManager.play()
-        }
-    }
-
-    fun seekTo(positionMs: Long) {
-        playbackManager.seekTo(positionMs)
-    }
-
-    fun skipForward() {
-        playbackManager.skipForward(skipIncrementMs.value)
-    }
-
-    fun skipBackward() {
-        playbackManager.skipBackward(skipIncrementMs.value)
-    }
-
-    fun skipToNext() {
-        playbackManager.skipToNext()
-    }
-
-    fun skipToPrevious() {
-        playbackManager.skipToPrevious()
-    }
-
-    // -- Repeat & shuffle --
-
-    fun cycleRepeatMode() {
-        val next = _uiState.value.repeatMode.next()
-        playbackManager.setRepeatMode(next)
-    }
-
-    fun toggleShuffle() {
-        playbackManager.setShuffleEnabled(!_uiState.value.shuffleEnabled)
-    }
-
-    // -- Speed --
-
-    fun setSpeed(speed: Float) {
-        playbackManager.setSpeed(speed)
-    }
-
-    fun toggleSpeedSheet() {
-        _uiState.update { it.copy(showSpeedSheet = !it.showSpeedSheet) }
-    }
-
-    fun dismissSpeedSheet() {
-        _uiState.update { it.copy(showSpeedSheet = false) }
-    }
-
-    // -- Queue --
-
-    fun toggleQueueSheet() {
-        _uiState.update { it.copy(showQueueSheet = !it.showQueueSheet) }
-    }
-
-    fun dismissQueueSheet() {
-        _uiState.update { it.copy(showQueueSheet = false) }
-    }
-
-    fun skipToQueueItem(index: Int) {
-        playbackManager.skipToQueueItem(index)
-    }
-
-    fun removeFromQueue(index: Int) {
-        playbackManager.removeFromQueue(index)
-    }
-
-    fun clearQueue() {
-        playbackManager.clearQueue()
-    }
-
-    // -- Bookmarks --
-
-    private fun observeBookmarks() {
-        viewModelScope.launch {
-            bookmarkRepository.getBookmarksForFile(audioFileId).collect { bookmarks ->
-                _uiState.update { it.copy(bookmarks = bookmarks) }
-            }
-        }
-    }
-
-    fun toggleMarkersSheet() {
-        _uiState.update { it.copy(showMarkersSheet = !it.showMarkersSheet) }
-    }
-
-    fun dismissMarkersSheet() {
-        _uiState.update { it.copy(showMarkersSheet = false) }
-    }
-
-    fun addBookmark() {
-        val positionMs = _uiState.value.playbackState.positionMs
-        val count = _uiState.value.bookmarks.size + 1
-        viewModelScope.launch {
-            bookmarkRepository.addBookmark(
-                audioFileId = audioFileId,
-                positionMs = positionMs,
-                name = "Bookmark $count",
-            )
-        }
-    }
-
-    fun renameBookmark(id: Long, name: String) {
-        viewModelScope.launch {
-            bookmarkRepository.renameBookmark(id, name)
-        }
-    }
-
-    fun updateBookmarkPosition(id: Long, positionMs: Long) {
-        viewModelScope.launch {
-            bookmarkRepository.updateBookmarkPosition(id, positionMs)
-        }
-    }
-
-    fun deleteBookmark(id: Long) {
-        viewModelScope.launch {
-            bookmarkRepository.deleteBookmark(id)
-        }
-    }
-
-    fun seekToBookmark(positionMs: Long) {
-        playbackManager.seekTo(positionMs)
-    }
-
-    // -- A-B Loops --
-
-    private fun observeLoops() {
-        viewModelScope.launch {
-            loopRepository.getLoopsForFile(audioFileId).collect { loops ->
-                _uiState.update { it.copy(savedLoops = loops) }
-            }
-        }
-    }
-
-    private fun observeLoopRegion() {
-        viewModelScope.launch {
-            playbackManager.loopRegion.collect { region ->
-                _uiState.update { state ->
-                    state.copy(
-                        activeLoop = region,
-                        // Auto-show the loops overlay when a loop is activated; auto-hide when cleared.
-                        overlayMode = when {
-                            region != null -> OverlayMode.LOOPS
-                            state.overlayMode == OverlayMode.LOOPS -> OverlayMode.NONE
-                            else -> state.overlayMode
-                        },
-                    )
-                }
-            }
-        }
-    }
-
-    fun dismissWaveform() {
-        playbackManager.clearLoopRegion()
-        _uiState.update { it.copy(overlayMode = OverlayMode.NONE) }
-        viewModelScope.launch {
-            userPreferencesRepository.setWaveformOverlay(OverlayMode.NONE)
-        }
-    }
-
-    fun setLoopA() {
-        val positionMs = _uiState.value.playbackState.positionMs
-        val current = _uiState.value.activeLoop
-        if (current != null && positionMs < current.endMs - 100) {
-            playbackManager.setLoopRegion(LoopRegion(positionMs, current.endMs))
-        } else {
-            // Store A temporarily — we'll set the full region when B is set
-            _uiState.update { it.copy(activeLoop = LoopRegion(positionMs, positionMs)) }
-        }
-    }
-
-    fun setLoopB() {
-        val positionMs = _uiState.value.playbackState.positionMs
-        val current = _uiState.value.activeLoop
-        val startMs = current?.startMs ?: 0L
-        if (positionMs > startMs + 100) {
-            playbackManager.setLoopRegion(LoopRegion(startMs, positionMs))
-        }
-    }
-
-    fun createLoop(startMs: Long, endMs: Long) {
-        if (endMs - startMs >= 100) {
-            playbackManager.setLoopRegion(LoopRegion(startMs, endMs))
-        }
-    }
-
-    fun clearLoop() {
-        playbackManager.clearLoopRegion()
-    }
-
-    fun saveLoop(name: String) {
-        val region = _uiState.value.activeLoop ?: return
-        viewModelScope.launch {
-            loopRepository.saveLoop(
-                audioFileId = audioFileId,
-                name = name,
-                startMs = region.startMs,
-                endMs = region.endMs,
-            )
-        }
-    }
-
-    fun loadLoop(loop: Loop) {
-        playbackManager.setLoopRegion(LoopRegion(loop.startMs, loop.endMs))
-        playbackManager.seekTo(loop.startMs)
-    }
-
-    fun deleteLoop(id: Long) {
-        viewModelScope.launch {
-            loopRepository.deleteLoop(id)
-        }
-    }
-
-    fun updateLoopBounds(loopId: Long) {
-        val region = _uiState.value.activeLoop ?: return
-        viewModelScope.launch {
-            loopRepository.updateBounds(loopId, region.startMs, region.endMs)
-        }
-    }
-
-    fun adjustLoopBoundary(isStart: Boolean, newMs: Long) {
-        val current = _uiState.value.activeLoop ?: return
-        val updated = if (isStart) {
-            var start = newMs.coerceAtLeast(0)
-            // Don't let begin go past current playback position
-            val pos = _uiState.value.playbackState.positionMs
-            if (pos > current.startMs) {
-                start = start.coerceAtMost(pos)
-            }
-            LoopRegion(start, current.endMs)
-        } else {
-            LoopRegion(current.startMs, newMs.coerceAtMost(_uiState.value.playbackState.durationMs))
-        }
-        if (updated.endMs - updated.startMs >= 100) {
-            playbackManager.setLoopRegion(updated)
-        }
-    }
-
-    // -- Chunks & Practice --
-
-    private fun observeChunkMarkers() {
-        viewModelScope.launch {
-            chunkMarkerRepository.getMarkersForFile(audioFileId).collect { markers ->
-                _uiState.update { it.copy(chunkMarkers = markers) }
-            }
-        }
-    }
-
-    private fun observePracticeState() {
-        viewModelScope.launch {
-            practiceEngine.state.collect { state ->
-                _uiState.update { it.copy(practiceState = state) }
-            }
-        }
-    }
-
-    private fun loadPracticeSettings() {
-        viewModelScope.launch {
-            val settings = practiceSettingsRepository.getForFile(audioFileId)
-            _uiState.update { it.copy(practiceSettings = settings) }
-        }
-    }
-
-    fun addChunkMarker() {
-        val positionMs = _uiState.value.playbackState.positionMs
-        val count = _uiState.value.chunkMarkers.size + 1
-        viewModelScope.launch {
-            chunkMarkerRepository.addMarker(
-                audioFileId = audioFileId,
-                positionMs = positionMs,
-                label = "Marker $count",
-            )
-        }
-    }
-
-    fun updateChunkMarkerPosition(id: Long, positionMs: Long) {
-        viewModelScope.launch {
-            chunkMarkerRepository.updatePosition(id, positionMs)
-        }
-    }
-
-    fun deleteChunkMarker(id: Long) {
-        viewModelScope.launch {
-            chunkMarkerRepository.deleteMarker(id)
-        }
-    }
-
-    fun seekToChunk(positionMs: Long) {
-        playbackManager.seekTo(positionMs)
-    }
-
-    fun togglePracticeSheet() {
-        _uiState.update { it.copy(showPracticeSheet = !it.showPracticeSheet) }
-    }
-
-    fun dismissPracticeSheet() {
-        _uiState.update { it.copy(showPracticeSheet = false) }
-    }
-
-    fun updatePracticeMode(mode: PracticeMode) {
-        val updated = _uiState.value.practiceSettings.copy(mode = mode)
-        _uiState.update { it.copy(practiceSettings = updated) }
-        savePracticeSettings(updated)
-    }
-
-    fun updateRepeatCount(count: Int) {
-        val updated = _uiState.value.practiceSettings.copy(repeatCount = count)
-        _uiState.update { it.copy(practiceSettings = updated) }
-        savePracticeSettings(updated)
-    }
-
-    fun updateGapBetweenReps(ms: Long) {
-        val updated = _uiState.value.practiceSettings.copy(gapBetweenRepsMs = ms)
-        _uiState.update { it.copy(practiceSettings = updated) }
-        savePracticeSettings(updated)
-    }
-
-    fun updateGapBetweenChunks(ms: Long) {
-        val updated = _uiState.value.practiceSettings.copy(gapBetweenChunksMs = ms)
-        _uiState.update { it.copy(practiceSettings = updated) }
-        savePracticeSettings(updated)
-    }
-
-    private fun savePracticeSettings(settings: PracticeSettings) {
-        viewModelScope.launch {
-            practiceSettingsRepository.save(audioFileId, settings)
-        }
-    }
-
-    fun startPractice() {
-        val markers = _uiState.value.chunkMarkers
-        val settings = _uiState.value.practiceSettings
-        val durationMs = _uiState.value.playbackState.durationMs
-
-        val steps = when (settings.mode) {
-            PracticeMode.SINGLE_CHUNK_LOOP ->
-                GeneratePracticeStepsUseCase.generateSingleChunkSteps(markers, durationMs, settings.repeatCount)
-            PracticeMode.CUMULATIVE_BUILD_UP ->
-                GeneratePracticeStepsUseCase.generateCumulativeBuildUpSteps(markers, durationMs, settings.repeatCount)
-            PracticeMode.SEQUENTIAL_PLAY ->
-                GeneratePracticeStepsUseCase.generateSequentialSteps(markers, durationMs)
-        }
-
-        practiceEngine.startPractice(steps, settings, viewModelScope)
-    }
-
-    fun stopPractice() {
-        practiceEngine.stopPractice()
-    }
-
-    fun practiceSkipNext() {
-        practiceEngine.skipToNextStep()
-    }
-
-    fun practiceSkipPrevious() {
-        practiceEngine.skipToPreviousStep()
-    }
-
-    // -- Lifecycle: save position & speed when leaving --
-
-    override fun onCleared() {
-        super.onCleared()
-        val state = _uiState.value.playbackState
-        viewModelScope.launch {
-            repository.updateLastPlayed(audioFileId, state.positionMs)
-            repository.updateLastSpeed(audioFileId, state.speed)
-            Timber.d("Saved playback state for id=%d: pos=%dms, speed=%.2fx",
-                audioFileId, state.positionMs, state.speed)
-        }
-    }
-}

--- a/app/src/main/java/com/rehearsall/ui/playback/components/BookmarkTabContent.kt
+++ b/app/src/main/java/com/rehearsall/ui/playback/components/BookmarkTabContent.kt
@@ -55,9 +55,10 @@ fun BookmarkTabContent(
                 text = "No bookmarks yet.\nTap + to add one at the current position.",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier
-                    .align(Alignment.Center)
-                    .padding(24.dp),
+                modifier =
+                    Modifier
+                        .align(Alignment.Center)
+                        .padding(24.dp),
             )
         } else {
             LazyColumn(
@@ -78,9 +79,10 @@ fun BookmarkTabContent(
 
         FloatingActionButton(
             onClick = onAdd,
-            modifier = Modifier
-                .align(Alignment.BottomEnd)
-                .padding(16.dp),
+            modifier =
+                Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(16.dp),
         ) {
             Icon(Icons.Default.Add, contentDescription = "Add bookmark")
         }
@@ -120,10 +122,11 @@ private fun BookmarkRow(
     onDelete: () -> Unit,
 ) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onTap)
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onTap)
+                .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(modifier = Modifier.weight(1f)) {

--- a/app/src/main/java/com/rehearsall/ui/playback/components/ChunkTabContent.kt
+++ b/app/src/main/java/com/rehearsall/ui/playback/components/ChunkTabContent.kt
@@ -52,9 +52,10 @@ fun ChunkTabContent(
         Column(modifier = Modifier.fillMaxSize()) {
             if (markers.isEmpty()) {
                 Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .weight(1f),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .weight(1f),
                     contentAlignment = Alignment.Center,
                 ) {
                     Text(
@@ -66,9 +67,10 @@ fun ChunkTabContent(
                 }
             } else {
                 LazyColumn(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .weight(1f),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .weight(1f),
                     verticalArrangement = Arrangement.spacedBy(2.dp),
                 ) {
                     itemsIndexed(markers, key = { _, m -> m.id }) { index, marker ->
@@ -87,9 +89,10 @@ fun ChunkTabContent(
                 // Start Practice button
                 FilledTonalButton(
                     onClick = onStartPractice,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 12.dp),
                 ) {
                     Icon(Icons.Default.PlayArrow, contentDescription = null, modifier = Modifier.padding(end = 8.dp))
                     Text("Start Practice")
@@ -99,10 +102,11 @@ fun ChunkTabContent(
 
         FloatingActionButton(
             onClick = onAddMarker,
-            modifier = Modifier
-                .align(Alignment.BottomEnd)
-                .padding(16.dp)
-                .padding(bottom = if (markers.isNotEmpty()) 56.dp else 0.dp),
+            modifier =
+                Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(16.dp)
+                    .padding(bottom = if (markers.isNotEmpty()) 56.dp else 0.dp),
         ) {
             Icon(Icons.Default.Add, contentDescription = "Add chunk marker")
         }
@@ -131,10 +135,11 @@ private fun ChunkMarkerRow(
     onDelete: () -> Unit,
 ) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onTap)
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onTap)
+                .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(

--- a/app/src/main/java/com/rehearsall/ui/playback/components/ChunkTabContent.kt
+++ b/app/src/main/java/com/rehearsall/ui/playback/components/ChunkTabContent.kt
@@ -59,7 +59,9 @@ fun ChunkTabContent(
                     contentAlignment = Alignment.Center,
                 ) {
                     Text(
-                        text = "No chunk markers yet.\nTap + to add one at the current position.\nMarkers divide the track into chunks for practice.",
+                        text =
+                            "No chunk markers yet.\nTap + to add one at the current position.\n" +
+                                "Markers divide the track into chunks for practice.",
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.padding(24.dp),

--- a/app/src/main/java/com/rehearsall/ui/playback/components/LoopTabContent.kt
+++ b/app/src/main/java/com/rehearsall/ui/playback/components/LoopTabContent.kt
@@ -27,7 +27,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -70,21 +69,24 @@ fun LoopTabContent(
 
     Box(modifier = modifier.fillMaxSize()) {
         Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(horizontal = 16.dp),
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 16.dp),
         ) {
             // Active loop editor — distinct card with close button
             if (activeLoop != null && activeLoop.endMs > activeLoop.startMs) {
                 Spacer(modifier = Modifier.height(8.dp))
                 OutlinedCard(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = CardDefaults.outlinedCardColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-                    ),
-                    border = CardDefaults.outlinedCardBorder().copy(
-                        width = 1.dp,
-                    ),
+                    colors =
+                        CardDefaults.outlinedCardColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                        ),
+                    border =
+                        CardDefaults.outlinedCardBorder().copy(
+                            width = 1.dp,
+                        ),
                 ) {
                     Column(modifier = Modifier.padding(12.dp)) {
                         // Header row with title and close button
@@ -131,10 +133,11 @@ fun LoopTabContent(
                                 TextButton(onClick = { editingBoundary = true }) {
                                     Text(
                                         text = formatDuration(activeLoop.startMs),
-                                        style = MaterialTheme.typography.titleLarge.copy(
-                                            fontWeight = FontWeight.Medium,
-                                            textDecoration = TextDecoration.Underline,
-                                        ),
+                                        style =
+                                            MaterialTheme.typography.titleLarge.copy(
+                                                fontWeight = FontWeight.Medium,
+                                                textDecoration = TextDecoration.Underline,
+                                            ),
                                     )
                                 }
                                 Spacer(modifier = Modifier.height(4.dp))
@@ -145,9 +148,10 @@ fun LoopTabContent(
                                             onAdjustBoundary(true, newMs)
                                             onSeekTo(newMs)
                                         },
-                                        colors = IconButtonDefaults.filledIconButtonColors(
-                                            containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                                        ),
+                                        colors =
+                                            IconButtonDefaults.filledIconButtonColors(
+                                                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                                            ),
                                     ) {
                                         Icon(Icons.Default.Remove, contentDescription = "−0.25s")
                                     }
@@ -157,9 +161,10 @@ fun LoopTabContent(
                                             onAdjustBoundary(true, newMs)
                                             onSeekTo(newMs)
                                         },
-                                        colors = IconButtonDefaults.filledIconButtonColors(
-                                            containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                                        ),
+                                        colors =
+                                            IconButtonDefaults.filledIconButtonColors(
+                                                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                                            ),
                                     ) {
                                         Icon(Icons.Default.Add, contentDescription = "+0.25s")
                                     }
@@ -180,10 +185,11 @@ fun LoopTabContent(
                                 TextButton(onClick = { editingBoundary = false }) {
                                     Text(
                                         text = formatDuration(activeLoop.endMs),
-                                        style = MaterialTheme.typography.titleLarge.copy(
-                                            fontWeight = FontWeight.Medium,
-                                            textDecoration = TextDecoration.Underline,
-                                        ),
+                                        style =
+                                            MaterialTheme.typography.titleLarge.copy(
+                                                fontWeight = FontWeight.Medium,
+                                                textDecoration = TextDecoration.Underline,
+                                            ),
                                     )
                                 }
                                 Spacer(modifier = Modifier.height(4.dp))
@@ -192,9 +198,10 @@ fun LoopTabContent(
                                         onClick = {
                                             onAdjustBoundary(false, (activeLoop.endMs - 250).coerceAtLeast(activeLoop.startMs + 100))
                                         },
-                                        colors = IconButtonDefaults.filledIconButtonColors(
-                                            containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                                        ),
+                                        colors =
+                                            IconButtonDefaults.filledIconButtonColors(
+                                                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                                            ),
                                     ) {
                                         Icon(Icons.Default.Remove, contentDescription = "−0.25s")
                                     }
@@ -202,9 +209,10 @@ fun LoopTabContent(
                                         onClick = {
                                             onAdjustBoundary(false, (activeLoop.endMs + 250).coerceAtMost(durationMs))
                                         },
-                                        colors = IconButtonDefaults.filledIconButtonColors(
-                                            containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                                        ),
+                                        colors =
+                                            IconButtonDefaults.filledIconButtonColors(
+                                                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                                            ),
                                     ) {
                                         Icon(Icons.Default.Add, contentDescription = "+0.25s")
                                     }
@@ -257,9 +265,10 @@ fun LoopTabContent(
 
             if (savedLoops.isEmpty()) {
                 Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .weight(1f),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .weight(1f),
                     contentAlignment = Alignment.Center,
                 ) {
                     Text(
@@ -293,9 +302,10 @@ fun LoopTabContent(
                 editingLoop = null
                 onCreateLoop(0L, durationMs)
             },
-            modifier = Modifier
-                .align(Alignment.BottomEnd)
-                .padding(16.dp),
+            modifier =
+                Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(16.dp),
         ) {
             Icon(Icons.Default.Add, contentDescription = "Create loop")
         }
@@ -364,10 +374,11 @@ private fun SavedLoopRow(
     onDelete: () -> Unit,
 ) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onTap)
-            .padding(horizontal = 0.dp, vertical = 12.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onTap)
+                .padding(horizontal = 0.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(modifier = Modifier.weight(1f)) {

--- a/app/src/main/java/com/rehearsall/ui/playback/components/MarkersBottomSheet.kt
+++ b/app/src/main/java/com/rehearsall/ui/playback/components/MarkersBottomSheet.kt
@@ -101,15 +101,18 @@ fun MarkersBottomSheet(
                 val duration = durationMs.coerceAtLeast(1L)
                 val positionFraction = positionMs.toFloat() / duration.toFloat()
 
-                val loopStartFrac = activeLoop?.let {
-                    if (it.endMs > it.startMs) it.startMs.toFloat() / duration else null
-                }
-                val loopEndFrac = activeLoop?.let {
-                    if (it.endMs > it.startMs) it.endMs.toFloat() / duration else null
-                }
-                val chunkFractions = chunkMarkers.map {
-                    it.positionMs.toFloat() / duration
-                }
+                val loopStartFrac =
+                    activeLoop?.let {
+                        if (it.endMs > it.startMs) it.startMs.toFloat() / duration else null
+                    }
+                val loopEndFrac =
+                    activeLoop?.let {
+                        if (it.endMs > it.startMs) it.endMs.toFloat() / duration else null
+                    }
+                val chunkFractions =
+                    chunkMarkers.map {
+                        it.positionMs.toFloat() / duration
+                    }
                 val practiceStep = (practiceState as? PracticeState.Playing)?.currentStep
                 val activeChunkStart = practiceStep?.let { it.startMs.toFloat() / duration }
                 val activeChunkEnd = practiceStep?.let { it.endMs.toFloat() / duration }
@@ -124,9 +127,10 @@ fun MarkersBottomSheet(
                     onSeek = { fraction ->
                         onSeek((fraction * duration).toLong())
                     },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp),
                     height = 160.dp,
                     zoom = wfZoom,
                     scrollOffset = wfScroll,
@@ -146,9 +150,10 @@ fun MarkersBottomSheet(
 
                 // Play/pause and zoom controls
                 Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
@@ -222,37 +227,40 @@ fun MarkersBottomSheet(
                 modifier = Modifier.weight(1f),
             ) { page ->
                 when (page) {
-                    0 -> LoopTabContent(
-                        activeLoop = activeLoop,
-                        savedLoops = savedLoops,
-                        onCreateLoop = onCreateLoop,
-                        onClearLoop = onClearLoop,
-                        onSaveLoop = onSaveLoop,
-                        onLoadLoop = onLoadLoop,
-                        onDeleteLoop = onDeleteLoop,
-                        onUpdateLoopBounds = onUpdateLoopBounds,
-                        onAdjustBoundary = onAdjustLoopBoundary,
-                        onSeekTo = onSeek,
-                        durationMs = durationMs,
-                    )
-                    1 -> ChunkTabContent(
-                        markers = chunkMarkers,
-                        onSeekTo = onSeekToChunk,
-                        onAddMarker = onAddChunkMarker,
-                        onUpdatePosition = onUpdateChunkMarkerPosition,
-                        onDeleteMarker = onDeleteChunkMarker,
-                        onStartPractice = onStartPractice,
-                        durationMs = durationMs,
-                    )
-                    2 -> BookmarkTabContent(
-                        bookmarks = bookmarks,
-                        onSeekTo = onSeekToBookmark,
-                        onAdd = onAddBookmark,
-                        onRename = onRenameBookmark,
-                        onUpdatePosition = onUpdateBookmarkPosition,
-                        onDelete = onDeleteBookmark,
-                        durationMs = durationMs,
-                    )
+                    0 ->
+                        LoopTabContent(
+                            activeLoop = activeLoop,
+                            savedLoops = savedLoops,
+                            onCreateLoop = onCreateLoop,
+                            onClearLoop = onClearLoop,
+                            onSaveLoop = onSaveLoop,
+                            onLoadLoop = onLoadLoop,
+                            onDeleteLoop = onDeleteLoop,
+                            onUpdateLoopBounds = onUpdateLoopBounds,
+                            onAdjustBoundary = onAdjustLoopBoundary,
+                            onSeekTo = onSeek,
+                            durationMs = durationMs,
+                        )
+                    1 ->
+                        ChunkTabContent(
+                            markers = chunkMarkers,
+                            onSeekTo = onSeekToChunk,
+                            onAddMarker = onAddChunkMarker,
+                            onUpdatePosition = onUpdateChunkMarkerPosition,
+                            onDeleteMarker = onDeleteChunkMarker,
+                            onStartPractice = onStartPractice,
+                            durationMs = durationMs,
+                        )
+                    2 ->
+                        BookmarkTabContent(
+                            bookmarks = bookmarks,
+                            onSeekTo = onSeekToBookmark,
+                            onAdd = onAddBookmark,
+                            onRename = onRenameBookmark,
+                            onUpdatePosition = onUpdateBookmarkPosition,
+                            onDelete = onDeleteBookmark,
+                            durationMs = durationMs,
+                        )
                 }
             }
         }

--- a/app/src/main/java/com/rehearsall/ui/playback/components/PracticeControlsBottomSheet.kt
+++ b/app/src/main/java/com/rehearsall/ui/playback/components/PracticeControlsBottomSheet.kt
@@ -55,10 +55,11 @@ fun PracticeControlsBottomSheet(
         sheetState = sheetState,
     ) {
         Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp)
-                .padding(bottom = 24.dp),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .padding(bottom = 24.dp),
         ) {
             Text(
                 text = "Practice Controls",
@@ -107,9 +108,10 @@ private fun PracticeSettingsContent(
     )
     Row(
         horizontalArrangement = Arrangement.spacedBy(8.dp),
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 8.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp),
     ) {
         PracticeMode.entries.forEach { mode ->
             FilterChip(

--- a/app/src/main/java/com/rehearsall/ui/playback/components/QueueBottomSheet.kt
+++ b/app/src/main/java/com/rehearsall/ui/playback/components/QueueBottomSheet.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -15,7 +14,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -51,9 +49,10 @@ fun QueueBottomSheet(
         sheetState = sheetState,
     ) {
         Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
         ) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -77,14 +76,16 @@ fun QueueBottomSheet(
 
             if (queue.isEmpty()) {
                 Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(200.dp),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .height(200.dp),
                     contentAlignment = Alignment.Center,
                 ) {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
                         Icon(
-                            Icons.Default.MusicNote, null,
+                            Icons.Default.MusicNote,
+                            null,
                             tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
                         )
                         Spacer(modifier = Modifier.height(8.dp))
@@ -97,9 +98,10 @@ fun QueueBottomSheet(
                 }
             } else {
                 LazyColumn(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(400.dp),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .height(400.dp),
                 ) {
                     itemsIndexed(queue) { index, item ->
                         QueueItemRow(
@@ -120,18 +122,20 @@ private fun QueueItemRow(
     item: QueueItem,
     onClick: () -> Unit,
 ) {
-    val bgColor = if (item.isCurrentlyPlaying) {
-        MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f)
-    } else {
-        MaterialTheme.colorScheme.surface
-    }
+    val bgColor =
+        if (item.isCurrentlyPlaying) {
+            MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f)
+        } else {
+            MaterialTheme.colorScheme.surface
+        }
 
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(bgColor)
-            .clickable(onClick = onClick)
-            .padding(horizontal = 8.dp, vertical = 12.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .background(bgColor)
+                .clickable(onClick = onClick)
+                .padding(horizontal = 8.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         if (item.isCurrentlyPlaying) {

--- a/app/src/main/java/com/rehearsall/ui/playback/components/SpeedControlBottomSheet.kt
+++ b/app/src/main/java/com/rehearsall/ui/playback/components/SpeedControlBottomSheet.kt
@@ -36,9 +36,10 @@ fun SpeedControlBottomSheet(
         sheetState = sheetState,
     ) {
         Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 24.dp, vertical = 16.dp),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp, vertical = 16.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Text(

--- a/app/src/main/java/com/rehearsall/ui/playback/components/TransportBar.kt
+++ b/app/src/main/java/com/rehearsall/ui/playback/components/TransportBar.kt
@@ -14,7 +14,6 @@ import androidx.compose.material.icons.filled.RepeatOne
 import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SkipPrevious
-import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -49,13 +48,14 @@ fun TransportBar(
         // Shuffle
         IconButton(
             onClick = onToggleShuffle,
-            colors = if (shuffleEnabled) {
-                IconButtonDefaults.iconButtonColors(
-                    contentColor = MaterialTheme.colorScheme.primary,
-                )
-            } else {
-                IconButtonDefaults.iconButtonColors()
-            },
+            colors =
+                if (shuffleEnabled) {
+                    IconButtonDefaults.iconButtonColors(
+                        contentColor = MaterialTheme.colorScheme.primary,
+                    )
+                } else {
+                    IconButtonDefaults.iconButtonColors()
+                },
         ) {
             Icon(
                 imageVector = Icons.Default.Shuffle,
@@ -112,25 +112,28 @@ fun TransportBar(
         // Repeat mode
         IconButton(
             onClick = onCycleRepeat,
-            colors = if (repeatMode != RepeatMode.OFF) {
-                IconButtonDefaults.iconButtonColors(
-                    contentColor = MaterialTheme.colorScheme.primary,
-                )
-            } else {
-                IconButtonDefaults.iconButtonColors()
-            },
+            colors =
+                if (repeatMode != RepeatMode.OFF) {
+                    IconButtonDefaults.iconButtonColors(
+                        contentColor = MaterialTheme.colorScheme.primary,
+                    )
+                } else {
+                    IconButtonDefaults.iconButtonColors()
+                },
         ) {
             Icon(
-                imageVector = when (repeatMode) {
-                    RepeatMode.OFF -> Icons.Default.Repeat
-                    RepeatMode.ONE -> Icons.Default.RepeatOne
-                    RepeatMode.ALL -> Icons.Default.Repeat
-                },
-                contentDescription = when (repeatMode) {
-                    RepeatMode.OFF -> "Repeat off"
-                    RepeatMode.ONE -> "Repeat one"
-                    RepeatMode.ALL -> "Repeat all"
-                },
+                imageVector =
+                    when (repeatMode) {
+                        RepeatMode.OFF -> Icons.Default.Repeat
+                        RepeatMode.ONE -> Icons.Default.RepeatOne
+                        RepeatMode.ALL -> Icons.Default.Repeat
+                    },
+                contentDescription =
+                    when (repeatMode) {
+                        RepeatMode.OFF -> "Repeat off"
+                        RepeatMode.ONE -> "Repeat one"
+                        RepeatMode.ALL -> "Repeat all"
+                    },
             )
         }
     }

--- a/app/src/main/java/com/rehearsall/ui/playback/components/WaveformOverviewBar.kt
+++ b/app/src/main/java/com/rehearsall/ui/playback/components/WaveformOverviewBar.kt
@@ -42,37 +42,38 @@ fun WaveformOverviewBar(
     val currentVpEnd by rememberUpdatedState(viewportEnd)
 
     Canvas(
-        modifier = modifier
-            .fillMaxWidth()
-            .height(24.dp)
-            .then(
-                if (onViewportDrag != null) {
-                    Modifier.pointerInput(Unit) {
-                        val vpWidth = { currentVpEnd - currentVpStart }
-                        awaitEachGesture {
-                            val down = awaitFirstDown(requireUnconsumed = false)
-                            val canvasW = size.width.toFloat()
-                            // Center viewport on tap position
-                            val fraction = (down.position.x / canvasW).coerceIn(0f, 1f)
-                            val halfVp = vpWidth() / 2f
-                            onViewportDrag(
-                                (fraction - halfVp).coerceIn(0f, (1f - vpWidth()).coerceAtLeast(0f))
-                            )
-
-                            drag(down.id) { change ->
-                                change.consume()
-                                val f = (change.position.x / canvasW).coerceIn(0f, 1f)
-                                val hw = vpWidth() / 2f
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .height(24.dp)
+                .then(
+                    if (onViewportDrag != null) {
+                        Modifier.pointerInput(Unit) {
+                            val vpWidth = { currentVpEnd - currentVpStart }
+                            awaitEachGesture {
+                                val down = awaitFirstDown(requireUnconsumed = false)
+                                val canvasW = size.width.toFloat()
+                                // Center viewport on tap position
+                                val fraction = (down.position.x / canvasW).coerceIn(0f, 1f)
+                                val halfVp = vpWidth() / 2f
                                 onViewportDrag(
-                                    (f - hw).coerceIn(0f, (1f - vpWidth()).coerceAtLeast(0f))
+                                    (fraction - halfVp).coerceIn(0f, (1f - vpWidth()).coerceAtLeast(0f)),
                                 )
+
+                                drag(down.id) { change ->
+                                    change.consume()
+                                    val f = (change.position.x / canvasW).coerceIn(0f, 1f)
+                                    val hw = vpWidth() / 2f
+                                    onViewportDrag(
+                                        (f - hw).coerceIn(0f, (1f - vpWidth()).coerceAtLeast(0f)),
+                                    )
+                                }
                             }
                         }
-                    }
-                } else {
-                    Modifier
-                }
-            ),
+                    } else {
+                        Modifier
+                    },
+                ),
     ) {
         val canvasWidth = size.width
         val canvasHeight = size.height

--- a/app/src/main/java/com/rehearsall/ui/playback/components/WaveformView.kt
+++ b/app/src/main/java/com/rehearsall/ui/playback/components/WaveformView.kt
@@ -87,7 +87,7 @@ fun WaveformView(
             val cursorInView = positionFraction - s
             if (cursorInView > vw * 0.8f || cursorInView < vw * 0.1f) {
                 onScrollOffsetChange(
-                    (positionFraction - vw * 0.3f).coerceIn(0f, 1f - vw)
+                    (positionFraction - vw * 0.3f).coerceIn(0f, 1f - vw),
                 )
             }
         }
@@ -97,123 +97,128 @@ fun WaveformView(
     val bottomOverhangDp = if (showPositionHandle) 16.dp else 0.dp
 
     Canvas(
-        modifier = modifier
-            .fillMaxWidth()
-            .height(height + topOverhangDp + bottomOverhangDp)
-            .pointerInput(amplitudes) {
-                // Pinch-to-zoom in its own block so two-finger gestures don't conflict
-                detectTransformGestures { _, _, gestureZoom, _ ->
-                    val z = currentZoom
-                    val s = currentScroll
-                    val newZoom = (z * gestureZoom).coerceIn(1f, 50f)
-                    val viewportCenter = s + (1f / z) / 2f
-                    val newVW = 1f / newZoom
-                    val newScroll = (viewportCenter - newVW / 2f)
-                        .coerceIn(0f, (1f - newVW).coerceAtLeast(0f))
-                    onZoomChange(newZoom)
-                    onScrollOffsetChange(newScroll)
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .height(height + topOverhangDp + bottomOverhangDp)
+                .pointerInput(amplitudes) {
+                    // Pinch-to-zoom in its own block so two-finger gestures don't conflict
+                    detectTransformGestures { _, _, gestureZoom, _ ->
+                        val z = currentZoom
+                        val s = currentScroll
+                        val newZoom = (z * gestureZoom).coerceIn(1f, 50f)
+                        val viewportCenter = s + (1f / z) / 2f
+                        val newVW = 1f / newZoom
+                        val newScroll =
+                            (viewportCenter - newVW / 2f)
+                                .coerceIn(0f, (1f - newVW).coerceAtLeast(0f))
+                        onZoomChange(newZoom)
+                        onScrollOffsetChange(newScroll)
+                    }
                 }
-            }
-            .pointerInput(amplitudes, editable, showPositionHandle) {
-                // Single-finger: tap-to-seek, loop boundary drag, position handle drag, or scroll
-                val handleHitPx = 56f
-                val boundarySlop = 2f   // Very low for smooth handle scrubbing
-                val generalSlop = 10f
+                .pointerInput(amplitudes, editable, showPositionHandle) {
+                    // Single-finger: tap-to-seek, loop boundary drag, position handle drag, or scroll
+                    val handleHitPx = 56f
+                    val boundarySlop = 2f // Very low for smooth handle scrubbing
+                    val generalSlop = 10f
 
-                awaitEachGesture {
-                    val down = awaitFirstDown(requireUnconsumed = false)
-                    val downX = down.position.x
-                    val downY = down.position.y
-                    val canvasW = size.width.toFloat()
-                    val canvasH = size.height.toFloat()
-                    val z = currentZoom
-                    val s = currentScroll
-                    val vw = 1f / z
+                    awaitEachGesture {
+                        val down = awaitFirstDown(requireUnconsumed = false)
+                        val downX = down.position.x
+                        val downY = down.position.y
+                        val canvasW = size.width.toFloat()
+                        val canvasH = size.height.toFloat()
+                        val z = currentZoom
+                        val s = currentScroll
+                        val vw = 1f / z
 
-                    // Check proximity to loop boundary handles (editable only)
-                    var nearBoundary: Boolean? = null
-                    val ls = currentLoopStart
-                    val le = currentLoopEnd
-                    if (editable && ls != null && le != null && onLoopBoundaryDrag != null) {
-                        val startX = ((ls - s) / vw) * canvasW
-                        val endX = ((le - s) / vw) * canvasW
-                        val distStart = abs(downX - startX)
-                        val distEnd = abs(downX - endX)
-                        if (distStart < handleHitPx || distEnd < handleHitPx) {
-                            nearBoundary = distStart <= distEnd
-                        }
-                    }
-
-                    // Check proximity to position scrub handle
-                    var nearPosition = false
-                    if (showPositionHandle) {
-                        val posX = ((currentPosition - s) / vw) * canvasW
-                        if (abs(downX - posX) < handleHitPx) {
-                            nearPosition = true
-                        }
-                    }
-
-                    // Disambiguate: if both nearby, use Y (top = boundary, bottom = position)
-                    if (nearBoundary != null && nearPosition) {
-                        if (downY > canvasH * 0.5f) {
-                            nearBoundary = null
-                        } else {
-                            nearPosition = false
-                        }
-                    }
-
-                    val slop = if (nearBoundary != null || nearPosition) boundarySlop else generalSlop
-                    var dragged = false
-                    var action: String? = null
-
-                    drag(down.id) { change ->
-                        if (!dragged && abs(change.position.x - downX) > slop) {
-                            dragged = true
-                            action = when {
-                                nearBoundary != null -> "boundary"
-                                nearPosition -> "position"
-                                else -> "scroll"
+                        // Check proximity to loop boundary handles (editable only)
+                        var nearBoundary: Boolean? = null
+                        val ls = currentLoopStart
+                        val le = currentLoopEnd
+                        if (editable && ls != null && le != null && onLoopBoundaryDrag != null) {
+                            val startX = ((ls - s) / vw) * canvasW
+                            val endX = ((le - s) / vw) * canvasW
+                            val distStart = abs(downX - startX)
+                            val distEnd = abs(downX - endX)
+                            if (distStart < handleHitPx || distEnd < handleHitPx) {
+                                nearBoundary = distStart <= distEnd
                             }
                         }
-                        if (dragged) {
-                            change.consume()
-                            val cz = currentZoom
-                            val cs = currentScroll
-                            when (action) {
-                                "boundary" -> {
-                                    val f = tapToFraction(change.position.x, canvasW, cz, cs)
-                                        .coerceIn(0f, 1f)
-                                    onLoopBoundaryDrag?.invoke(nearBoundary!!, f)
-                                }
-                                "position" -> {
-                                    val f = tapToFraction(change.position.x, canvasW, cz, cs)
-                                        .coerceIn(0f, 1f)
-                                    onSeek(f)
-                                }
-                                "scroll" -> {
-                                    if (cz > 1f) {
-                                        val dx = change.positionChange().x
-                                        val cvw = 1f / cz
-                                        val delta = -dx / canvasW * cvw
-                                        onScrollOffsetChange(
-                                            (cs + delta).coerceIn(
-                                                0f,
-                                                (1f - cvw).coerceAtLeast(0f),
+
+                        // Check proximity to position scrub handle
+                        var nearPosition = false
+                        if (showPositionHandle) {
+                            val posX = ((currentPosition - s) / vw) * canvasW
+                            if (abs(downX - posX) < handleHitPx) {
+                                nearPosition = true
+                            }
+                        }
+
+                        // Disambiguate: if both nearby, use Y (top = boundary, bottom = position)
+                        if (nearBoundary != null && nearPosition) {
+                            if (downY > canvasH * 0.5f) {
+                                nearBoundary = null
+                            } else {
+                                nearPosition = false
+                            }
+                        }
+
+                        val slop = if (nearBoundary != null || nearPosition) boundarySlop else generalSlop
+                        var dragged = false
+                        var action: String? = null
+
+                        drag(down.id) { change ->
+                            if (!dragged && abs(change.position.x - downX) > slop) {
+                                dragged = true
+                                action =
+                                    when {
+                                        nearBoundary != null -> "boundary"
+                                        nearPosition -> "position"
+                                        else -> "scroll"
+                                    }
+                            }
+                            if (dragged) {
+                                change.consume()
+                                val cz = currentZoom
+                                val cs = currentScroll
+                                when (action) {
+                                    "boundary" -> {
+                                        val f =
+                                            tapToFraction(change.position.x, canvasW, cz, cs)
+                                                .coerceIn(0f, 1f)
+                                        onLoopBoundaryDrag?.invoke(nearBoundary!!, f)
+                                    }
+                                    "position" -> {
+                                        val f =
+                                            tapToFraction(change.position.x, canvasW, cz, cs)
+                                                .coerceIn(0f, 1f)
+                                        onSeek(f)
+                                    }
+                                    "scroll" -> {
+                                        if (cz > 1f) {
+                                            val dx = change.positionChange().x
+                                            val cvw = 1f / cz
+                                            val delta = -dx / canvasW * cvw
+                                            onScrollOffsetChange(
+                                                (cs + delta).coerceIn(
+                                                    0f,
+                                                    (1f - cvw).coerceAtLeast(0f),
+                                                ),
                                             )
-                                        )
+                                        }
                                     }
                                 }
                             }
                         }
-                    }
 
-                    if (!dragged) {
-                        val cz = currentZoom
-                        val cs = currentScroll
-                        onSeek(tapToFraction(downX, canvasW, cz, cs).coerceIn(0f, 1f))
+                        if (!dragged) {
+                            val cz = currentZoom
+                            val cs = currentScroll
+                            onSeek(tapToFraction(downX, canvasW, cz, cs).coerceIn(0f, 1f))
+                        }
                     }
-                }
-            },
+                },
     ) {
         val canvasWidth = size.width
         val canvasHeight = size.height
@@ -332,10 +337,12 @@ fun WaveformView(
 
         // Loop region
         if (loopStartFraction != null && loopEndFraction != null && loopEndFraction > loopStartFraction) {
-            val loopLX = ((loopStartFraction - startFrac) / viewportWidth * canvasWidth)
-                .coerceIn(0f, canvasWidth)
-            val loopRX = ((loopEndFraction - startFrac) / viewportWidth * canvasWidth)
-                .coerceIn(0f, canvasWidth)
+            val loopLX =
+                ((loopStartFraction - startFrac) / viewportWidth * canvasWidth)
+                    .coerceIn(0f, canvasWidth)
+            val loopRX =
+                ((loopEndFraction - startFrac) / viewportWidth * canvasWidth)
+                    .coerceIn(0f, canvasWidth)
 
             if (editable) {
                 // Semi-transparent overlay between A and B

--- a/app/src/main/java/com/rehearsall/ui/playlist/PlaylistScreen.kt
+++ b/app/src/main/java/com/rehearsall/ui/playlist/PlaylistScreen.kt
@@ -23,9 +23,9 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.DragHandle
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -138,7 +138,8 @@ fun PlaylistScreen(
                                 },
                                 leadingIcon = {
                                     Icon(
-                                        Icons.Default.Delete, null,
+                                        Icons.Default.Delete,
+                                        null,
                                         tint = MaterialTheme.colorScheme.error,
                                     )
                                 },
@@ -167,9 +168,10 @@ fun PlaylistScreen(
         when (val state = uiState) {
             is PlaylistUiState.Loading -> {
                 Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(innerPadding),
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding),
                     contentAlignment = Alignment.Center,
                 ) {
                     CircularProgressIndicator()
@@ -192,9 +194,10 @@ fun PlaylistScreen(
 
             is PlaylistUiState.Error -> {
                 Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(innerPadding),
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding),
                     contentAlignment = Alignment.Center,
                 ) {
                     Text(
@@ -282,12 +285,14 @@ private fun PlaylistItemList(
     var localItems by remember(items) { mutableStateOf(items) }
 
     val lazyListState = rememberLazyListState()
-    val reorderState = rememberReorderableLazyListState(lazyListState) { from, to ->
-        localItems = localItems.toMutableList().apply {
-            add(to.index, removeAt(from.index))
+    val reorderState =
+        rememberReorderableLazyListState(lazyListState) { from, to ->
+            localItems =
+                localItems.toMutableList().apply {
+                    add(to.index, removeAt(from.index))
+                }
+            onReorder(from.index, to.index)
         }
-        onReorder(from.index, to.index)
-    }
 
     LazyColumn(
         state = lazyListState,
@@ -304,33 +309,36 @@ private fun PlaylistItemList(
                     label = "drag-elevation",
                 )
 
-                val dismissState = rememberSwipeToDismissBoxState(
-                    confirmValueChange = { value ->
-                        if (value == SwipeToDismissBoxValue.EndToStart) {
-                            onRemove(item.id)
-                            true
-                        } else {
-                            false
-                        }
-                    },
-                )
+                val dismissState =
+                    rememberSwipeToDismissBoxState(
+                        confirmValueChange = { value ->
+                            if (value == SwipeToDismissBoxValue.EndToStart) {
+                                onRemove(item.id)
+                                true
+                            } else {
+                                false
+                            }
+                        },
+                    )
 
                 SwipeToDismissBox(
                     state = dismissState,
                     backgroundContent = {
                         val color by animateColorAsState(
-                            targetValue = if (dismissState.targetValue == SwipeToDismissBoxValue.EndToStart) {
-                                MaterialTheme.colorScheme.errorContainer
-                            } else {
-                                MaterialTheme.colorScheme.surface
-                            },
+                            targetValue =
+                                if (dismissState.targetValue == SwipeToDismissBoxValue.EndToStart) {
+                                    MaterialTheme.colorScheme.errorContainer
+                                } else {
+                                    MaterialTheme.colorScheme.surface
+                                },
                             label = "swipe-bg",
                         )
                         Box(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .background(color)
-                                .padding(horizontal = 24.dp),
+                            modifier =
+                                Modifier
+                                    .fillMaxSize()
+                                    .background(color)
+                                    .padding(horizontal = 24.dp),
                             contentAlignment = Alignment.CenterEnd,
                         ) {
                             Icon(
@@ -366,11 +374,12 @@ private fun PlaylistTrackRow(
     dragHandleModifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .background(MaterialTheme.colorScheme.surface)
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .background(MaterialTheme.colorScheme.surface)
+                .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(

--- a/app/src/main/java/com/rehearsall/ui/playlist/PlaylistUiState.kt
+++ b/app/src/main/java/com/rehearsall/ui/playlist/PlaylistUiState.kt
@@ -4,15 +4,19 @@ import com.rehearsall.domain.model.PlaylistItem
 
 sealed interface PlaylistUiState {
     data object Loading : PlaylistUiState
+
     data class Loaded(
         val playlistName: String,
         val items: List<PlaylistItem>,
     ) : PlaylistUiState
+
     data class Error(val message: String) : PlaylistUiState
 }
 
 sealed interface PlaylistEvent {
     data class ItemRemoved(val displayName: String) : PlaylistEvent
+
     data class PlaylistDeleted(val name: String) : PlaylistEvent
+
     data class PlaylistRenamed(val newName: String) : PlaylistEvent
 }

--- a/app/src/main/java/com/rehearsall/ui/playlist/PlaylistViewModel.kt
+++ b/app/src/main/java/com/rehearsall/ui/playlist/PlaylistViewModel.kt
@@ -20,103 +20,110 @@ import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
-class PlaylistViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle,
-    private val playlistRepository: PlaylistRepository,
-    private val playbackManager: PlaybackManager,
-) : ViewModel() {
+class PlaylistViewModel
+    @Inject
+    constructor(
+        savedStateHandle: SavedStateHandle,
+        private val playlistRepository: PlaylistRepository,
+        private val playbackManager: PlaybackManager,
+    ) : ViewModel() {
+        private val playlistId: Long =
+            savedStateHandle["playlistId"]
+                ?: throw IllegalArgumentException("playlistId required")
 
-    private val playlistId: Long = savedStateHandle["playlistId"]
-        ?: throw IllegalArgumentException("playlistId required")
+        private val _uiState = MutableStateFlow<PlaylistUiState>(PlaylistUiState.Loading)
+        val uiState: StateFlow<PlaylistUiState> = _uiState.asStateFlow()
 
-    private val _uiState = MutableStateFlow<PlaylistUiState>(PlaylistUiState.Loading)
-    val uiState: StateFlow<PlaylistUiState> = _uiState.asStateFlow()
+        private val _events = MutableSharedFlow<PlaylistEvent>()
+        val events: SharedFlow<PlaylistEvent> = _events.asSharedFlow()
 
-    private val _events = MutableSharedFlow<PlaylistEvent>()
-    val events: SharedFlow<PlaylistEvent> = _events.asSharedFlow()
+        init {
+            loadPlaylist()
+        }
 
-    init {
-        loadPlaylist()
-    }
+        private fun loadPlaylist() {
+            viewModelScope.launch {
+                val playlist = playlistRepository.getById(playlistId)
+                if (playlist == null) {
+                    _uiState.value = PlaylistUiState.Error("Playlist not found")
+                    return@launch
+                }
 
-    private fun loadPlaylist() {
-        viewModelScope.launch {
-            val playlist = playlistRepository.getById(playlistId)
-            if (playlist == null) {
-                _uiState.value = PlaylistUiState.Error("Playlist not found")
-                return@launch
+                playlistRepository.getPlaylistItems(playlistId)
+                    .map<_, PlaylistUiState> { items ->
+                        PlaylistUiState.Loaded(
+                            playlistName = playlist.name,
+                            items = items,
+                        )
+                    }
+                    .catch { e ->
+                        Timber.e(e, "Error loading playlist items")
+                        emit(PlaylistUiState.Error("Failed to load playlist"))
+                    }
+                    .collect { _uiState.value = it }
             }
+        }
 
-            playlistRepository.getPlaylistItems(playlistId)
-                .map<_, PlaylistUiState> { items ->
-                    PlaylistUiState.Loaded(
-                        playlistName = playlist.name,
-                        items = items,
+        fun playPlaylist(startIndex: Int = 0) {
+            val state = _uiState.value as? PlaylistUiState.Loaded ?: return
+            if (state.items.isEmpty()) return
+
+            val queueItems =
+                state.items.map { item ->
+                    QueueItem(
+                        fileId = item.audioFileId,
+                        displayName = item.displayName,
+                        artist = item.artist,
+                        durationMs = item.durationMs,
+                        path = item.internalPath,
                     )
                 }
-                .catch { e ->
-                    Timber.e(e, "Error loading playlist items")
-                    emit(PlaylistUiState.Error("Failed to load playlist"))
-                }
-                .collect { _uiState.value = it }
+            playbackManager.setQueue(queueItems, startIndex)
         }
-    }
 
-    fun playPlaylist(startIndex: Int = 0) {
-        val state = _uiState.value as? PlaylistUiState.Loaded ?: return
-        if (state.items.isEmpty()) return
-
-        val queueItems = state.items.map { item ->
-            QueueItem(
-                fileId = item.audioFileId,
-                displayName = item.displayName,
-                artist = item.artist,
-                durationMs = item.durationMs,
-                path = item.internalPath,
-            )
-        }
-        playbackManager.setQueue(queueItems, startIndex)
-    }
-
-    fun removeItem(itemId: Long) {
-        viewModelScope.launch {
-            val state = _uiState.value as? PlaylistUiState.Loaded ?: return@launch
-            val item = state.items.find { it.id == itemId } ?: return@launch
-            playlistRepository.removeItem(itemId, playlistId)
-            _events.emit(PlaylistEvent.ItemRemoved(item.displayName))
-        }
-    }
-
-    fun reorderItems(fromIndex: Int, toIndex: Int) {
-        val state = _uiState.value as? PlaylistUiState.Loaded ?: return
-        val items = state.items.toMutableList()
-        val item = items.removeAt(fromIndex)
-        items.add(toIndex, item)
-
-        // Update order indices
-        viewModelScope.launch {
-            val updates = items.mapIndexed { index, playlistItem ->
-                playlistItem.id to index
+        fun removeItem(itemId: Long) {
+            viewModelScope.launch {
+                val state = _uiState.value as? PlaylistUiState.Loaded ?: return@launch
+                val item = state.items.find { it.id == itemId } ?: return@launch
+                playlistRepository.removeItem(itemId, playlistId)
+                _events.emit(PlaylistEvent.ItemRemoved(item.displayName))
             }
-            playlistRepository.reorderItems(playlistId, updates)
         }
-    }
 
-    fun renamePlaylist(newName: String) {
-        viewModelScope.launch {
-            playlistRepository.renamePlaylist(playlistId, newName.trim())
-            // Update local state immediately
-            val current = _uiState.value as? PlaylistUiState.Loaded ?: return@launch
-            _uiState.value = current.copy(playlistName = newName.trim())
-            _events.emit(PlaylistEvent.PlaylistRenamed(newName.trim()))
-        }
-    }
+        fun reorderItems(
+            fromIndex: Int,
+            toIndex: Int,
+        ) {
+            val state = _uiState.value as? PlaylistUiState.Loaded ?: return
+            val items = state.items.toMutableList()
+            val item = items.removeAt(fromIndex)
+            items.add(toIndex, item)
 
-    fun deletePlaylist() {
-        viewModelScope.launch {
-            val state = _uiState.value as? PlaylistUiState.Loaded
-            playlistRepository.deletePlaylist(playlistId)
-            _events.emit(PlaylistEvent.PlaylistDeleted(state?.playlistName ?: "Playlist"))
+            // Update order indices
+            viewModelScope.launch {
+                val updates =
+                    items.mapIndexed { index, playlistItem ->
+                        playlistItem.id to index
+                    }
+                playlistRepository.reorderItems(playlistId, updates)
+            }
+        }
+
+        fun renamePlaylist(newName: String) {
+            viewModelScope.launch {
+                playlistRepository.renamePlaylist(playlistId, newName.trim())
+                // Update local state immediately
+                val current = _uiState.value as? PlaylistUiState.Loaded ?: return@launch
+                _uiState.value = current.copy(playlistName = newName.trim())
+                _events.emit(PlaylistEvent.PlaylistRenamed(newName.trim()))
+            }
+        }
+
+        fun deletePlaylist() {
+            viewModelScope.launch {
+                val state = _uiState.value as? PlaylistUiState.Loaded
+                playlistRepository.deletePlaylist(playlistId)
+                _events.emit(PlaylistEvent.PlaylistDeleted(state?.playlistName ?: "Playlist"))
+            }
         }
     }
-}

--- a/app/src/main/java/com/rehearsall/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/rehearsall/ui/settings/SettingsScreen.kt
@@ -33,10 +33,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -70,10 +70,11 @@ fun SettingsScreen(
         },
     ) { innerPadding ->
         Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding)
-                .verticalScroll(rememberScrollState()),
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .verticalScroll(rememberScrollState()),
         ) {
             // -- Appearance --
             SectionHeader("Appearance")
@@ -121,23 +122,25 @@ private fun ThemeModeSelector(
     selected: ThemeMode,
     onSelect: (ThemeMode) -> Unit,
 ) {
-    val options = listOf(
-        ThemeMode.LIGHT to "Light",
-        ThemeMode.DARK to "Dark",
-        ThemeMode.SYSTEM to "Follow System",
-    )
+    val options =
+        listOf(
+            ThemeMode.LIGHT to "Light",
+            ThemeMode.DARK to "Dark",
+            ThemeMode.SYSTEM to "Follow System",
+        )
     Column(modifier = Modifier.selectableGroup()) {
         options.forEach { (mode, label) ->
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .selectable(
-                        selected = selected == mode,
-                        onClick = { onSelect(mode) },
-                        role = Role.RadioButton,
-                    )
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .selectable(
+                            selected = selected == mode,
+                            onClick = { onSelect(mode) },
+                            role = Role.RadioButton,
+                        )
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
             ) {
                 RadioButton(
                     selected = selected == mode,
@@ -170,14 +173,15 @@ private fun SkipIncrementSelector(
             val label = "${ms / 1000} seconds"
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .selectable(
-                        selected = selectedMs == ms,
-                        onClick = { onSelect(ms) },
-                        role = Role.RadioButton,
-                    )
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .selectable(
+                            selected = selectedMs == ms,
+                            onClick = { onSelect(ms) },
+                            role = Role.RadioButton,
+                        )
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
             ) {
                 RadioButton(
                     selected = selectedMs == ms,
@@ -201,11 +205,12 @@ private fun SwitchRow(
     onCheckedChange: (Boolean) -> Unit,
 ) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable { onCheckedChange(!checked) }
-            .padding(horizontal = 16.dp, vertical = 12.dp)
-            .semantics { contentDescription = "$label: ${if (checked) "on" else "off"}" },
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable { onCheckedChange(!checked) }
+                .padding(horizontal = 16.dp, vertical = 12.dp)
+                .semantics { contentDescription = "$label: ${if (checked) "on" else "off"}" },
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -246,17 +251,20 @@ private fun AboutSection() {
         Spacer(modifier = Modifier.height(8.dp))
         Text(
             text = "Documentation & Wiki",
-            style = MaterialTheme.typography.bodyMedium.copy(
-                textDecoration = TextDecoration.Underline,
-            ),
+            style =
+                MaterialTheme.typography.bodyMedium.copy(
+                    textDecoration = TextDecoration.Underline,
+                ),
             color = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.clickable {
-                val intent = Intent(
-                    Intent.ACTION_VIEW,
-                    Uri.parse("https://github.com/XeroIP/RehearsAll/wiki"),
-                )
-                context.startActivity(intent)
-            },
+            modifier =
+                Modifier.clickable {
+                    val intent =
+                        Intent(
+                            Intent.ACTION_VIEW,
+                            Uri.parse("https://github.com/XeroIP/RehearsAll/wiki"),
+                        )
+                    context.startActivity(intent)
+                },
         )
     }
     Spacer(modifier = Modifier.height(24.dp))

--- a/app/src/main/java/com/rehearsall/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/rehearsall/ui/settings/SettingsViewModel.kt
@@ -19,35 +19,37 @@ data class SettingsUiState(
 )
 
 @HiltViewModel
-class SettingsViewModel @Inject constructor(
-    private val prefsRepo: UserPreferencesRepository,
-) : ViewModel() {
+class SettingsViewModel
+    @Inject
+    constructor(
+        private val prefsRepo: UserPreferencesRepository,
+    ) : ViewModel() {
+        val uiState: StateFlow<SettingsUiState> =
+            combine(
+                prefsRepo.themeMode,
+                prefsRepo.skipIncrementMs,
+                prefsRepo.loopCrossfade,
+            ) { theme, skip, crossfade ->
+                SettingsUiState(
+                    themeMode = theme,
+                    skipIncrementMs = skip,
+                    loopCrossfade = crossfade,
+                )
+            }.stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5_000),
+                initialValue = SettingsUiState(),
+            )
 
-    val uiState: StateFlow<SettingsUiState> = combine(
-        prefsRepo.themeMode,
-        prefsRepo.skipIncrementMs,
-        prefsRepo.loopCrossfade,
-    ) { theme, skip, crossfade ->
-        SettingsUiState(
-            themeMode = theme,
-            skipIncrementMs = skip,
-            loopCrossfade = crossfade,
-        )
-    }.stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(5_000),
-        initialValue = SettingsUiState(),
-    )
+        fun setThemeMode(mode: ThemeMode) {
+            viewModelScope.launch { prefsRepo.setThemeMode(mode) }
+        }
 
-    fun setThemeMode(mode: ThemeMode) {
-        viewModelScope.launch { prefsRepo.setThemeMode(mode) }
+        fun setSkipIncrement(ms: Long) {
+            viewModelScope.launch { prefsRepo.setSkipIncrementMs(ms) }
+        }
+
+        fun setLoopCrossfade(enabled: Boolean) {
+            viewModelScope.launch { prefsRepo.setLoopCrossfade(enabled) }
+        }
     }
-
-    fun setSkipIncrement(ms: Long) {
-        viewModelScope.launch { prefsRepo.setSkipIncrementMs(ms) }
-    }
-
-    fun setLoopCrossfade(enabled: Boolean) {
-        viewModelScope.launch { prefsRepo.setLoopCrossfade(enabled) }
-    }
-}

--- a/app/src/main/java/com/rehearsall/ui/theme/Theme.kt
+++ b/app/src/main/java/com/rehearsall/ui/theme/Theme.kt
@@ -10,59 +10,61 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 
-private val LightColorScheme = lightColorScheme(
-    primary = md_theme_light_primary,
-    onPrimary = md_theme_light_onPrimary,
-    primaryContainer = md_theme_light_primaryContainer,
-    onPrimaryContainer = md_theme_light_onPrimaryContainer,
-    secondary = md_theme_light_secondary,
-    onSecondary = md_theme_light_onSecondary,
-    secondaryContainer = md_theme_light_secondaryContainer,
-    onSecondaryContainer = md_theme_light_onSecondaryContainer,
-    tertiary = md_theme_light_tertiary,
-    onTertiary = md_theme_light_onTertiary,
-    tertiaryContainer = md_theme_light_tertiaryContainer,
-    onTertiaryContainer = md_theme_light_onTertiaryContainer,
-    error = md_theme_light_error,
-    onError = md_theme_light_onError,
-    errorContainer = md_theme_light_errorContainer,
-    onErrorContainer = md_theme_light_onErrorContainer,
-    background = md_theme_light_background,
-    onBackground = md_theme_light_onBackground,
-    surface = md_theme_light_surface,
-    onSurface = md_theme_light_onSurface,
-    surfaceVariant = md_theme_light_surfaceVariant,
-    onSurfaceVariant = md_theme_light_onSurfaceVariant,
-    outline = md_theme_light_outline,
-    outlineVariant = md_theme_light_outlineVariant,
-)
+private val LightColorScheme =
+    lightColorScheme(
+        primary = md_theme_light_primary,
+        onPrimary = md_theme_light_onPrimary,
+        primaryContainer = md_theme_light_primaryContainer,
+        onPrimaryContainer = md_theme_light_onPrimaryContainer,
+        secondary = md_theme_light_secondary,
+        onSecondary = md_theme_light_onSecondary,
+        secondaryContainer = md_theme_light_secondaryContainer,
+        onSecondaryContainer = md_theme_light_onSecondaryContainer,
+        tertiary = md_theme_light_tertiary,
+        onTertiary = md_theme_light_onTertiary,
+        tertiaryContainer = md_theme_light_tertiaryContainer,
+        onTertiaryContainer = md_theme_light_onTertiaryContainer,
+        error = md_theme_light_error,
+        onError = md_theme_light_onError,
+        errorContainer = md_theme_light_errorContainer,
+        onErrorContainer = md_theme_light_onErrorContainer,
+        background = md_theme_light_background,
+        onBackground = md_theme_light_onBackground,
+        surface = md_theme_light_surface,
+        onSurface = md_theme_light_onSurface,
+        surfaceVariant = md_theme_light_surfaceVariant,
+        onSurfaceVariant = md_theme_light_onSurfaceVariant,
+        outline = md_theme_light_outline,
+        outlineVariant = md_theme_light_outlineVariant,
+    )
 
-private val DarkColorScheme = darkColorScheme(
-    primary = md_theme_dark_primary,
-    onPrimary = md_theme_dark_onPrimary,
-    primaryContainer = md_theme_dark_primaryContainer,
-    onPrimaryContainer = md_theme_dark_onPrimaryContainer,
-    secondary = md_theme_dark_secondary,
-    onSecondary = md_theme_dark_onSecondary,
-    secondaryContainer = md_theme_dark_secondaryContainer,
-    onSecondaryContainer = md_theme_dark_onSecondaryContainer,
-    tertiary = md_theme_dark_tertiary,
-    onTertiary = md_theme_dark_onTertiary,
-    tertiaryContainer = md_theme_dark_tertiaryContainer,
-    onTertiaryContainer = md_theme_dark_onTertiaryContainer,
-    error = md_theme_dark_error,
-    onError = md_theme_dark_onError,
-    errorContainer = md_theme_dark_errorContainer,
-    onErrorContainer = md_theme_dark_onErrorContainer,
-    background = md_theme_dark_background,
-    onBackground = md_theme_dark_onBackground,
-    surface = md_theme_dark_surface,
-    onSurface = md_theme_dark_onSurface,
-    surfaceVariant = md_theme_dark_surfaceVariant,
-    onSurfaceVariant = md_theme_dark_onSurfaceVariant,
-    outline = md_theme_dark_outline,
-    outlineVariant = md_theme_dark_outlineVariant,
-)
+private val DarkColorScheme =
+    darkColorScheme(
+        primary = md_theme_dark_primary,
+        onPrimary = md_theme_dark_onPrimary,
+        primaryContainer = md_theme_dark_primaryContainer,
+        onPrimaryContainer = md_theme_dark_onPrimaryContainer,
+        secondary = md_theme_dark_secondary,
+        onSecondary = md_theme_dark_onSecondary,
+        secondaryContainer = md_theme_dark_secondaryContainer,
+        onSecondaryContainer = md_theme_dark_onSecondaryContainer,
+        tertiary = md_theme_dark_tertiary,
+        onTertiary = md_theme_dark_onTertiary,
+        tertiaryContainer = md_theme_dark_tertiaryContainer,
+        onTertiaryContainer = md_theme_dark_onTertiaryContainer,
+        error = md_theme_dark_error,
+        onError = md_theme_dark_onError,
+        errorContainer = md_theme_dark_errorContainer,
+        onErrorContainer = md_theme_dark_onErrorContainer,
+        background = md_theme_dark_background,
+        onBackground = md_theme_dark_onBackground,
+        surface = md_theme_dark_surface,
+        onSurface = md_theme_dark_onSurface,
+        surfaceVariant = md_theme_dark_surfaceVariant,
+        onSurfaceVariant = md_theme_dark_onSurfaceVariant,
+        outline = md_theme_dark_outline,
+        outlineVariant = md_theme_dark_outlineVariant,
+    )
 
 /**
  * RehearsAll Material 3 theme with dynamic color support.
@@ -78,17 +80,21 @@ fun RehearsAllTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit,
 ) {
-    val colorScheme = when {
-        // Dynamic color available on Android 12+
-        Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context)
-            else dynamicLightColorScheme(context)
+    val colorScheme =
+        when {
+            // Dynamic color available on Android 12+
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+                val context = LocalContext.current
+                if (darkTheme) {
+                    dynamicDarkColorScheme(context)
+                } else {
+                    dynamicLightColorScheme(context)
+                }
+            }
+            // Fallback for Android 8–11
+            darkTheme -> DarkColorScheme
+            else -> LightColorScheme
         }
-        // Fallback for Android 8–11
-        darkTheme -> DarkColorScheme
-        else -> LightColorScheme
-    }
 
     MaterialTheme(
         colorScheme = colorScheme,

--- a/app/src/test/java/com/rehearsall/ui/filelist/FileListViewModelImportTest.kt
+++ b/app/src/test/java/com/rehearsall/ui/filelist/FileListViewModelImportTest.kt
@@ -6,7 +6,6 @@ import com.rehearsall.data.audio.AudioImporter
 import com.rehearsall.data.repository.AudioFileRepository
 import com.rehearsall.data.repository.PlaylistRepository
 import com.rehearsall.domain.model.AudioFile
-import java.time.Instant
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -23,29 +22,30 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.time.Instant
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class FileListViewModelImportTest {
-
     private val testDispatcher = StandardTestDispatcher()
 
     private lateinit var importer: AudioImporter
     private lateinit var viewModel: FileListViewModel
 
-    private val fakeFile = AudioFile(
-        id = 1L,
-        displayName = "Track One",
-        artist = null,
-        title = null,
-        format = "mp3",
-        durationMs = 60_000L,
-        fileSizeBytes = 0L,
-        internalPath = "/data/track1.mp3",
-        importedAt = Instant.EPOCH,
-        lastPlayedAt = null,
-        lastPositionMs = 0L,
-        lastSpeed = 1f,
-    )
+    private val fakeFile =
+        AudioFile(
+            id = 1L,
+            displayName = "Track One",
+            artist = null,
+            title = null,
+            format = "mp3",
+            durationMs = 60_000L,
+            fileSizeBytes = 0L,
+            internalPath = "/data/track1.mp3",
+            importedAt = Instant.EPOCH,
+            lastPlayedAt = null,
+            lastPositionMs = 0L,
+            lastSpeed = 1f,
+        )
 
     private val uri1 = mockk<Uri>(relaxed = true)
     private val uri2 = mockk<Uri>(relaxed = true)
@@ -57,19 +57,22 @@ class FileListViewModelImportTest {
 
         importer = mockk(relaxed = true)
 
-        val repository = mockk<AudioFileRepository>(relaxed = true) {
-            every { getAllFiles() } returns flowOf(emptyList())
-        }
-        val playlistRepository = mockk<PlaylistRepository>(relaxed = true) {
-            every { getAllPlaylists() } returns flowOf(emptyList())
-        }
+        val repository =
+            mockk<AudioFileRepository>(relaxed = true) {
+                every { getAllFiles() } returns flowOf(emptyList())
+            }
+        val playlistRepository =
+            mockk<PlaylistRepository>(relaxed = true) {
+                every { getAllPlaylists() } returns flowOf(emptyList())
+            }
 
-        viewModel = FileListViewModel(
-            repository = repository,
-            playlistRepository = playlistRepository,
-            importer = importer,
-            playbackManager = mockk(relaxed = true),
-        )
+        viewModel =
+            FileListViewModel(
+                repository = repository,
+                playlistRepository = playlistRepository,
+                importer = importer,
+                playbackManager = mockk(relaxed = true),
+            )
 
         testDispatcher.scheduler.advanceUntilIdle()
     }
@@ -80,67 +83,72 @@ class FileListViewModelImportTest {
     }
 
     @Test
-    fun `importFiles with empty list does nothing`() = runTest {
-        viewModel.events.test {
-            viewModel.importFiles(emptyList())
-            testDispatcher.scheduler.advanceUntilIdle()
-            expectNoEvents()
+    fun `importFiles with empty list does nothing`() =
+        runTest {
+            viewModel.events.test {
+                viewModel.importFiles(emptyList())
+                testDispatcher.scheduler.advanceUntilIdle()
+                expectNoEvents()
+            }
         }
-    }
 
     @Test
-    fun `importFiles with single uri delegates to importFile and emits ImportSuccess`() = runTest {
-        coEvery { importer.import(uri1) } returns Result.success(fakeFile)
+    fun `importFiles with single uri delegates to importFile and emits ImportSuccess`() =
+        runTest {
+            coEvery { importer.import(uri1) } returns Result.success(fakeFile)
 
-        viewModel.events.test {
-            viewModel.importFiles(listOf(uri1))
-            testDispatcher.scheduler.advanceUntilIdle()
+            viewModel.events.test {
+                viewModel.importFiles(listOf(uri1))
+                testDispatcher.scheduler.advanceUntilIdle()
 
-            val event = awaitItem() as FileListEvent.ImportSuccess
-            assertEquals(fakeFile.displayName, event.displayName)
+                val event = awaitItem() as FileListEvent.ImportSuccess
+                assertEquals(fakeFile.displayName, event.displayName)
+            }
         }
-    }
 
     @Test
-    fun `importFiles with multiple uris emits ImportBatchComplete on all success`() = runTest {
-        coEvery { importer.import(uri1) } returns Result.success(fakeFile)
-        coEvery { importer.import(uri2) } returns Result.success(fakeFile.copy(id = 2L, displayName = "Track Two"))
-        coEvery { importer.import(uri3) } returns Result.success(fakeFile.copy(id = 3L, displayName = "Track Three"))
+    fun `importFiles with multiple uris emits ImportBatchComplete on all success`() =
+        runTest {
+            coEvery { importer.import(uri1) } returns Result.success(fakeFile)
+            coEvery { importer.import(uri2) } returns Result.success(fakeFile.copy(id = 2L, displayName = "Track Two"))
+            coEvery { importer.import(uri3) } returns Result.success(fakeFile.copy(id = 3L, displayName = "Track Three"))
 
-        viewModel.events.test {
-            viewModel.importFiles(listOf(uri1, uri2, uri3))
-            testDispatcher.scheduler.advanceUntilIdle()
+            viewModel.events.test {
+                viewModel.importFiles(listOf(uri1, uri2, uri3))
+                testDispatcher.scheduler.advanceUntilIdle()
 
-            val event = awaitItem() as FileListEvent.ImportBatchComplete
-            assertEquals(3, event.count)
+                val event = awaitItem() as FileListEvent.ImportBatchComplete
+                assertEquals(3, event.count)
+            }
         }
-    }
 
     @Test
-    fun `importFiles emits ImportError when some uris fail`() = runTest {
-        coEvery { importer.import(uri1) } returns Result.success(fakeFile)
-        coEvery { importer.import(uri2) } returns Result.failure(Exception("bad file"))
+    fun `importFiles emits ImportError when some uris fail`() =
+        runTest {
+            coEvery { importer.import(uri1) } returns Result.success(fakeFile)
+            coEvery { importer.import(uri2) } returns Result.failure(Exception("bad file"))
 
-        viewModel.events.test {
+            viewModel.events.test {
+                viewModel.importFiles(listOf(uri1, uri2))
+                testDispatcher.scheduler.advanceUntilIdle()
+
+                val batch = awaitItem() as FileListEvent.ImportBatchComplete
+                assertEquals(1, batch.count)
+
+                val error = awaitItem() as FileListEvent.ImportError
+                assertTrue(error.message.contains("1"))
+            }
+        }
+
+    @Test
+    fun `isImporting is false after batch import completes`() =
+        runTest {
+            coEvery { importer.import(uri1) } returns Result.success(fakeFile)
+            coEvery { importer.import(uri2) } returns Result.success(fakeFile.copy(id = 2L))
+
             viewModel.importFiles(listOf(uri1, uri2))
             testDispatcher.scheduler.advanceUntilIdle()
 
-            val batch = awaitItem() as FileListEvent.ImportBatchComplete
-            assertEquals(1, batch.count)
-
-            val error = awaitItem() as FileListEvent.ImportError
-            assertTrue(error.message.contains("1"))
+            assertFalse(viewModel.isImporting.value)
         }
-    }
-
-    @Test
-    fun `isImporting is false after batch import completes`() = runTest {
-        coEvery { importer.import(uri1) } returns Result.success(fakeFile)
-        coEvery { importer.import(uri2) } returns Result.success(fakeFile.copy(id = 2L))
-
-        viewModel.importFiles(listOf(uri1, uri2))
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        assertFalse(viewModel.isImporting.value)
-    }
 }

--- a/app/src/test/java/com/rehearsall/ui/filelist/FileListViewModelSelectionTest.kt
+++ b/app/src/test/java/com/rehearsall/ui/filelist/FileListViewModelSelectionTest.kt
@@ -1,14 +1,10 @@
 package com.rehearsall.ui.filelist
 
-import android.net.Uri
 import app.cash.turbine.test
-import com.rehearsall.data.audio.AudioImporter
 import com.rehearsall.data.repository.AudioFileRepository
 import com.rehearsall.data.repository.PlaylistRepository
 import com.rehearsall.domain.model.AudioFile
 import com.rehearsall.domain.model.Playlist
-import java.time.Instant
-import com.rehearsall.playback.PlaybackManager
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -26,10 +22,10 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.time.Instant
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class FileListViewModelSelectionTest {
-
     private val testDispatcher = StandardTestDispatcher()
 
     private lateinit var repository: AudioFileRepository
@@ -38,61 +34,67 @@ class FileListViewModelSelectionTest {
 
     private val now = Instant.EPOCH
 
-    private val file1 = AudioFile(
-        id = 1L,
-        displayName = "Track One",
-        artist = null,
-        title = null,
-        format = "mp3",
-        durationMs = 60_000L,
-        fileSizeBytes = 0L,
-        internalPath = "/data/track1.mp3",
-        importedAt = now,
-        lastPlayedAt = null,
-        lastPositionMs = 0L,
-        lastSpeed = 1f,
-    )
-    private val file2 = AudioFile(
-        id = 2L,
-        displayName = "Track Two",
-        artist = null,
-        title = null,
-        format = "mp3",
-        durationMs = 90_000L,
-        fileSizeBytes = 0L,
-        internalPath = "/data/track2.mp3",
-        importedAt = now,
-        lastPlayedAt = null,
-        lastPositionMs = 0L,
-        lastSpeed = 1f,
-    )
-    private val playlist = Playlist(
-        id = 10L,
-        name = "Favorites",
-        trackCount = 0,
-        totalDurationMs = 0L,
-        createdAt = now,
-        updatedAt = now,
-    )
+    private val file1 =
+        AudioFile(
+            id = 1L,
+            displayName = "Track One",
+            artist = null,
+            title = null,
+            format = "mp3",
+            durationMs = 60_000L,
+            fileSizeBytes = 0L,
+            internalPath = "/data/track1.mp3",
+            importedAt = now,
+            lastPlayedAt = null,
+            lastPositionMs = 0L,
+            lastSpeed = 1f,
+        )
+    private val file2 =
+        AudioFile(
+            id = 2L,
+            displayName = "Track Two",
+            artist = null,
+            title = null,
+            format = "mp3",
+            durationMs = 90_000L,
+            fileSizeBytes = 0L,
+            internalPath = "/data/track2.mp3",
+            importedAt = now,
+            lastPlayedAt = null,
+            lastPositionMs = 0L,
+            lastSpeed = 1f,
+        )
+    private val playlist =
+        Playlist(
+            id = 10L,
+            name = "Favorites",
+            trackCount = 0,
+            totalDurationMs = 0L,
+            createdAt = now,
+            updatedAt = now,
+        )
 
     @Before
     fun setup() {
         Dispatchers.setMain(testDispatcher)
 
-        repository = mockk(relaxed = true) {
-            every { getAllFiles() } returns flowOf(listOf(file1, file2))
-        }
-        playlistRepository = mockk(relaxed = true) {
-            every { getAllPlaylists() } returns flowOf(listOf(playlist))
-            coEvery { getById(playlist.id) } returns playlist
-        }
+        repository =
+            mockk(relaxed = true) {
+                every { getAllFiles() } returns flowOf(listOf(file1, file2))
+            }
+        playlistRepository =
+            mockk(relaxed = true) {
+                every { getAllPlaylists() } returns flowOf(listOf(playlist))
+                coEvery { getById(playlist.id) } returns playlist
+            }
 
-        viewModel = FileListViewModel(
-            repository = repository,
-            playlistRepository = playlistRepository,
-            importer = mockk(relaxed = true),
-            playbackManager = mockk(relaxed = true),
-        )
+        viewModel =
+            FileListViewModel(
+                repository = repository,
+                playlistRepository = playlistRepository,
+                importer = mockk(relaxed = true),
+                playbackManager = mockk(relaxed = true),
+            )
     }
 
     @After
@@ -107,130 +109,141 @@ class FileListViewModelSelectionTest {
     // --- toggleFileSelection ---
 
     @Test
-    fun `toggleFileSelection adds id to selectedFileIds`() = runTest {
-        advanceToLoaded()
+    fun `toggleFileSelection adds id to selectedFileIds`() =
+        runTest {
+            advanceToLoaded()
 
-        viewModel.toggleFileSelection(file1.id)
+            viewModel.toggleFileSelection(file1.id)
 
-        val state = viewModel.uiState.value as FileListUiState.Loaded
-        assertTrue(file1.id in state.selectedFileIds)
-    }
-
-    @Test
-    fun `toggleFileSelection removes id when already selected`() = runTest {
-        advanceToLoaded()
-        viewModel.toggleFileSelection(file1.id)
-
-        viewModel.toggleFileSelection(file1.id)
-
-        val state = viewModel.uiState.value as FileListUiState.Loaded
-        assertFalse(file1.id in state.selectedFileIds)
-    }
+            val state = viewModel.uiState.value as FileListUiState.Loaded
+            assertTrue(file1.id in state.selectedFileIds)
+        }
 
     @Test
-    fun `toggleFileSelection can select multiple ids independently`() = runTest {
-        advanceToLoaded()
+    fun `toggleFileSelection removes id when already selected`() =
+        runTest {
+            advanceToLoaded()
+            viewModel.toggleFileSelection(file1.id)
 
-        viewModel.toggleFileSelection(file1.id)
-        viewModel.toggleFileSelection(file2.id)
+            viewModel.toggleFileSelection(file1.id)
 
-        val state = viewModel.uiState.value as FileListUiState.Loaded
-        assertTrue(file1.id in state.selectedFileIds)
-        assertTrue(file2.id in state.selectedFileIds)
-    }
-
-    @Test
-    fun `isInSelectionMode is true when any file is selected`() = runTest {
-        advanceToLoaded()
-
-        viewModel.toggleFileSelection(file1.id)
-
-        val state = viewModel.uiState.value as FileListUiState.Loaded
-        assertTrue(state.isInSelectionMode)
-    }
+            val state = viewModel.uiState.value as FileListUiState.Loaded
+            assertFalse(file1.id in state.selectedFileIds)
+        }
 
     @Test
-    fun `isInSelectionMode is false when no files are selected`() = runTest {
-        advanceToLoaded()
+    fun `toggleFileSelection can select multiple ids independently`() =
+        runTest {
+            advanceToLoaded()
 
-        val state = viewModel.uiState.value as FileListUiState.Loaded
-        assertFalse(state.isInSelectionMode)
-    }
+            viewModel.toggleFileSelection(file1.id)
+            viewModel.toggleFileSelection(file2.id)
+
+            val state = viewModel.uiState.value as FileListUiState.Loaded
+            assertTrue(file1.id in state.selectedFileIds)
+            assertTrue(file2.id in state.selectedFileIds)
+        }
+
+    @Test
+    fun `isInSelectionMode is true when any file is selected`() =
+        runTest {
+            advanceToLoaded()
+
+            viewModel.toggleFileSelection(file1.id)
+
+            val state = viewModel.uiState.value as FileListUiState.Loaded
+            assertTrue(state.isInSelectionMode)
+        }
+
+    @Test
+    fun `isInSelectionMode is false when no files are selected`() =
+        runTest {
+            advanceToLoaded()
+
+            val state = viewModel.uiState.value as FileListUiState.Loaded
+            assertFalse(state.isInSelectionMode)
+        }
 
     // --- clearSelection ---
 
     @Test
-    fun `clearSelection empties selectedFileIds`() = runTest {
-        advanceToLoaded()
-        viewModel.toggleFileSelection(file1.id)
-        viewModel.toggleFileSelection(file2.id)
+    fun `clearSelection empties selectedFileIds`() =
+        runTest {
+            advanceToLoaded()
+            viewModel.toggleFileSelection(file1.id)
+            viewModel.toggleFileSelection(file2.id)
 
-        viewModel.clearSelection()
+            viewModel.clearSelection()
 
-        val state = viewModel.uiState.value as FileListUiState.Loaded
-        assertTrue(state.selectedFileIds.isEmpty())
-    }
+            val state = viewModel.uiState.value as FileListUiState.Loaded
+            assertTrue(state.selectedFileIds.isEmpty())
+        }
 
     @Test
-    fun `clearSelection on empty selection does not crash`() = runTest {
-        advanceToLoaded()
+    fun `clearSelection on empty selection does not crash`() =
+        runTest {
+            advanceToLoaded()
 
-        viewModel.clearSelection() // no-op, should not throw
+            viewModel.clearSelection() // no-op, should not throw
 
-        val state = viewModel.uiState.value as FileListUiState.Loaded
-        assertTrue(state.selectedFileIds.isEmpty())
-    }
+            val state = viewModel.uiState.value as FileListUiState.Loaded
+            assertTrue(state.selectedFileIds.isEmpty())
+        }
 
     // --- addSelectedToPlaylist ---
 
     @Test
-    fun `addSelectedToPlaylist calls addFileToPlaylist for each selected id`() = runTest {
-        advanceToLoaded()
-        viewModel.toggleFileSelection(file1.id)
-        viewModel.toggleFileSelection(file2.id)
+    fun `addSelectedToPlaylist calls addFileToPlaylist for each selected id`() =
+        runTest {
+            advanceToLoaded()
+            viewModel.toggleFileSelection(file1.id)
+            viewModel.toggleFileSelection(file2.id)
 
-        viewModel.addSelectedToPlaylist(playlist.id)
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        coVerify { playlistRepository.addFileToPlaylist(playlist.id, file1.id) }
-        coVerify { playlistRepository.addFileToPlaylist(playlist.id, file2.id) }
-    }
-
-    @Test
-    fun `addSelectedToPlaylist clears selection after adding`() = runTest {
-        advanceToLoaded()
-        viewModel.toggleFileSelection(file1.id)
-
-        viewModel.addSelectedToPlaylist(playlist.id)
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        val state = viewModel.uiState.value as FileListUiState.Loaded
-        assertTrue(state.selectedFileIds.isEmpty())
-    }
-
-    @Test
-    fun `addSelectedToPlaylist emits AddedBatchToPlaylist event`() = runTest {
-        advanceToLoaded()
-        viewModel.toggleFileSelection(file1.id)
-        viewModel.toggleFileSelection(file2.id)
-
-        viewModel.events.test {
             viewModel.addSelectedToPlaylist(playlist.id)
             testDispatcher.scheduler.advanceUntilIdle()
 
-            val event = awaitItem() as FileListEvent.AddedBatchToPlaylist
-            assertEquals(2, event.count)
-            assertEquals(playlist.name, event.playlistName)
+            coVerify { playlistRepository.addFileToPlaylist(playlist.id, file1.id) }
+            coVerify { playlistRepository.addFileToPlaylist(playlist.id, file2.id) }
         }
-    }
 
     @Test
-    fun `addSelectedToPlaylist does nothing when selection is empty`() = runTest {
-        advanceToLoaded()
+    fun `addSelectedToPlaylist clears selection after adding`() =
+        runTest {
+            advanceToLoaded()
+            viewModel.toggleFileSelection(file1.id)
 
-        viewModel.addSelectedToPlaylist(playlist.id)
-        testDispatcher.scheduler.advanceUntilIdle()
+            viewModel.addSelectedToPlaylist(playlist.id)
+            testDispatcher.scheduler.advanceUntilIdle()
 
-        coVerify(exactly = 0) { playlistRepository.addFileToPlaylist(any(), any()) }
-    }
+            val state = viewModel.uiState.value as FileListUiState.Loaded
+            assertTrue(state.selectedFileIds.isEmpty())
+        }
+
+    @Test
+    fun `addSelectedToPlaylist emits AddedBatchToPlaylist event`() =
+        runTest {
+            advanceToLoaded()
+            viewModel.toggleFileSelection(file1.id)
+            viewModel.toggleFileSelection(file2.id)
+
+            viewModel.events.test {
+                viewModel.addSelectedToPlaylist(playlist.id)
+                testDispatcher.scheduler.advanceUntilIdle()
+
+                val event = awaitItem() as FileListEvent.AddedBatchToPlaylist
+                assertEquals(2, event.count)
+                assertEquals(playlist.name, event.playlistName)
+            }
+        }
+
+    @Test
+    fun `addSelectedToPlaylist does nothing when selection is empty`() =
+        runTest {
+            advanceToLoaded()
+
+            viewModel.addSelectedToPlaylist(playlist.id)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            coVerify(exactly = 0) { playlistRepository.addFileToPlaylist(any(), any()) }
+        }
 }

--- a/app/src/test/java/com/rehearsall/ui/playback/PlaybackViewModelSkipTest.kt
+++ b/app/src/test/java/com/rehearsall/ui/playback/PlaybackViewModelSkipTest.kt
@@ -38,7 +38,6 @@ import org.junit.Test
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class PlaybackViewModelSkipTest {
-
     private val testDispatcher = StandardTestDispatcher()
 
     private lateinit var playbackManager: PlaybackManager
@@ -48,14 +47,15 @@ class PlaybackViewModelSkipTest {
     fun setup() {
         Dispatchers.setMain(testDispatcher)
 
-        playbackManager = mockk(relaxed = true) {
-            every { playbackState } returns MutableStateFlow(PlaybackState.IDLE)
-            every { currentFileId } returns currentFileIdFlow
-            every { repeatMode } returns MutableStateFlow(RepeatMode.OFF)
-            every { shuffleEnabled } returns MutableStateFlow(false)
-            every { currentQueue } returns MutableStateFlow(emptyList())
-            every { loopRegion } returns MutableStateFlow(null)
-        }
+        playbackManager =
+            mockk(relaxed = true) {
+                every { playbackState } returns MutableStateFlow(PlaybackState.IDLE)
+                every { currentFileId } returns currentFileIdFlow
+                every { repeatMode } returns MutableStateFlow(RepeatMode.OFF)
+                every { shuffleEnabled } returns MutableStateFlow(false)
+                every { currentQueue } returns MutableStateFlow(emptyList())
+                every { loopRegion } returns MutableStateFlow(null)
+            }
     }
 
     @After
@@ -64,31 +64,39 @@ class PlaybackViewModelSkipTest {
     }
 
     private fun createViewModel(fileId: Long = 1L): PlaybackViewModel {
-        val audioFileRepository = mockk<AudioFileRepository>(relaxed = true) {
-            coEvery { getById(any()) } returns null
-        }
-        val waveformRepository = mockk<WaveformRepository>(relaxed = true) {
-            every { getWaveform(any(), any()) } returns flowOf()
-        }
-        val bookmarkRepository = mockk<BookmarkRepository>(relaxed = true) {
-            every { getBookmarksForFile(any()) } returns flowOf(emptyList())
-        }
-        val loopRepository = mockk<LoopRepository>(relaxed = true) {
-            every { getLoopsForFile(any()) } returns flowOf(emptyList())
-        }
-        val chunkMarkerRepository = mockk<ChunkMarkerRepository>(relaxed = true) {
-            every { getMarkersForFile(any()) } returns flowOf(emptyList())
-        }
-        val practiceSettingsRepository = mockk<PracticeSettingsRepository>(relaxed = true) {
-            coEvery { getForFile(any()) } returns PracticeSettings()
-        }
-        val practiceEngine = mockk<ChunkedPracticeEngine>(relaxed = true) {
-            every { state } returns MutableStateFlow(PracticeState.Idle)
-        }
-        val userPreferencesRepository = mockk<UserPreferencesRepository>(relaxed = true) {
-            every { skipIncrementMs } returns MutableStateFlow(5000L)
-            every { waveformOverlay } returns MutableStateFlow(OverlayMode.NONE)
-        }
+        val audioFileRepository =
+            mockk<AudioFileRepository>(relaxed = true) {
+                coEvery { getById(any()) } returns null
+            }
+        val waveformRepository =
+            mockk<WaveformRepository>(relaxed = true) {
+                every { getWaveform(any(), any()) } returns flowOf()
+            }
+        val bookmarkRepository =
+            mockk<BookmarkRepository>(relaxed = true) {
+                every { getBookmarksForFile(any()) } returns flowOf(emptyList())
+            }
+        val loopRepository =
+            mockk<LoopRepository>(relaxed = true) {
+                every { getLoopsForFile(any()) } returns flowOf(emptyList())
+            }
+        val chunkMarkerRepository =
+            mockk<ChunkMarkerRepository>(relaxed = true) {
+                every { getMarkersForFile(any()) } returns flowOf(emptyList())
+            }
+        val practiceSettingsRepository =
+            mockk<PracticeSettingsRepository>(relaxed = true) {
+                coEvery { getForFile(any()) } returns PracticeSettings()
+            }
+        val practiceEngine =
+            mockk<ChunkedPracticeEngine>(relaxed = true) {
+                every { state } returns MutableStateFlow(PracticeState.Idle)
+            }
+        val userPreferencesRepository =
+            mockk<UserPreferencesRepository>(relaxed = true) {
+                every { skipIncrementMs } returns MutableStateFlow(5000L)
+                every { waveformOverlay } returns MutableStateFlow(OverlayMode.NONE)
+            }
 
         return PlaybackViewModel(
             savedStateHandle = SavedStateHandle(mapOf("audioFileId" to fileId)),
@@ -118,26 +126,28 @@ class PlaybackViewModelSkipTest {
         }
 
     @Test
-    fun `navigationEvent does not emit when currentFileId stays on the same file`() = runTest {
-        val viewModel = createViewModel(fileId = 1L)
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        viewModel.navigationEvent.test {
-            currentFileIdFlow.value = 1L
+    fun `navigationEvent does not emit when currentFileId stays on the same file`() =
+        runTest {
+            val viewModel = createViewModel(fileId = 1L)
             testDispatcher.scheduler.advanceUntilIdle()
-            expectNoEvents()
+
+            viewModel.navigationEvent.test {
+                currentFileIdFlow.value = 1L
+                testDispatcher.scheduler.advanceUntilIdle()
+                expectNoEvents()
+            }
         }
-    }
 
     @Test
-    fun `navigationEvent does not emit when currentFileId becomes null`() = runTest {
-        val viewModel = createViewModel(fileId = 1L)
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        viewModel.navigationEvent.test {
-            currentFileIdFlow.value = null
+    fun `navigationEvent does not emit when currentFileId becomes null`() =
+        runTest {
+            val viewModel = createViewModel(fileId = 1L)
             testDispatcher.scheduler.advanceUntilIdle()
-            expectNoEvents()
+
+            viewModel.navigationEvent.test {
+                currentFileIdFlow.value = null
+                testDispatcher.scheduler.advanceUntilIdle()
+                expectNoEvents()
+            }
         }
-    }
 }

--- a/app/src/test/java/com/rehearsall/ui/playback/PlaybackViewModelWaveformTest.kt
+++ b/app/src/test/java/com/rehearsall/ui/playback/PlaybackViewModelWaveformTest.kt
@@ -3,15 +3,8 @@ package com.rehearsall.ui.playback
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.rehearsall.data.preferences.UserPreferencesRepository
-import com.rehearsall.data.repository.AudioFileRepository
-import com.rehearsall.data.repository.BookmarkRepository
-import com.rehearsall.data.repository.ChunkMarkerRepository
-import com.rehearsall.data.repository.LoopRepository
-import com.rehearsall.data.repository.PracticeSettingsRepository
-import com.rehearsall.data.repository.WaveformRepository
 import com.rehearsall.domain.model.OverlayMode
 import com.rehearsall.domain.model.PracticeSettings
-import com.rehearsall.playback.ChunkedPracticeEngine
 import com.rehearsall.playback.LoopRegion
 import com.rehearsall.playback.PlaybackManager
 import com.rehearsall.playback.PlaybackState
@@ -45,7 +38,6 @@ import org.junit.Test
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class PlaybackViewModelWaveformTest {
-
     private val testDispatcher = StandardTestDispatcher()
 
     private val loopRegionFlow = MutableStateFlow<LoopRegion?>(null)
@@ -56,19 +48,21 @@ class PlaybackViewModelWaveformTest {
     fun setup() {
         Dispatchers.setMain(testDispatcher)
 
-        playbackManager = mockk(relaxed = true) {
-            every { playbackState } returns MutableStateFlow(PlaybackState.IDLE)
-            every { currentFileId } returns MutableStateFlow(1L)
-            every { repeatMode } returns MutableStateFlow(RepeatMode.OFF)
-            every { shuffleEnabled } returns MutableStateFlow(false)
-            every { currentQueue } returns MutableStateFlow(emptyList())
-            every { loopRegion } returns loopRegionFlow
-        }
+        playbackManager =
+            mockk(relaxed = true) {
+                every { playbackState } returns MutableStateFlow(PlaybackState.IDLE)
+                every { currentFileId } returns MutableStateFlow(1L)
+                every { repeatMode } returns MutableStateFlow(RepeatMode.OFF)
+                every { shuffleEnabled } returns MutableStateFlow(false)
+                every { currentQueue } returns MutableStateFlow(emptyList())
+                every { loopRegion } returns loopRegionFlow
+            }
 
-        userPreferencesRepository = mockk(relaxed = true) {
-            every { skipIncrementMs } returns MutableStateFlow(5000L)
-            every { waveformOverlay } returns MutableStateFlow(OverlayMode.NONE)
-        }
+        userPreferencesRepository =
+            mockk(relaxed = true) {
+                every { skipIncrementMs } returns MutableStateFlow(5000L)
+                every { waveformOverlay } returns MutableStateFlow(OverlayMode.NONE)
+            }
     }
 
     @After
@@ -92,68 +86,73 @@ class PlaybackViewModelWaveformTest {
     }
 
     @Test
-    fun `overlayMode becomes LOOPS when a loop region is set`() = runTest {
-        val viewModel = createViewModel()
-        testDispatcher.scheduler.advanceUntilIdle()
+    fun `overlayMode becomes LOOPS when a loop region is set`() =
+        runTest {
+            val viewModel = createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
 
-        viewModel.uiState.test {
-            awaitItem() // consume initial state
+            viewModel.uiState.test {
+                awaitItem() // consume initial state
+
+                loopRegionFlow.value = LoopRegion(1000L, 5000L)
+                testDispatcher.scheduler.advanceUntilIdle()
+
+                val state = awaitItem()
+                assertEquals(OverlayMode.LOOPS, state.overlayMode)
+            }
+        }
+
+    @Test
+    fun `overlayMode reverts to NONE when loop is cleared after being LOOPS`() =
+        runTest {
+            val viewModel = createViewModel()
+            loopRegionFlow.value = LoopRegion(1000L, 5000L)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            viewModel.uiState.test {
+                awaitItem() // current state (LOOPS)
+
+                loopRegionFlow.value = null
+                testDispatcher.scheduler.advanceUntilIdle()
+
+                val state = awaitItem()
+                assertEquals(OverlayMode.NONE, state.overlayMode)
+            }
+        }
+
+    @Test
+    fun `showWaveform is true when overlayMode is LOOPS`() =
+        runTest {
+            val viewModel = createViewModel()
+            testDispatcher.scheduler.advanceUntilIdle()
 
             loopRegionFlow.value = LoopRegion(1000L, 5000L)
             testDispatcher.scheduler.advanceUntilIdle()
 
-            val state = awaitItem()
-            assertEquals(OverlayMode.LOOPS, state.overlayMode)
+            assertTrue(viewModel.uiState.value.showWaveform)
         }
-    }
 
     @Test
-    fun `overlayMode reverts to NONE when loop is cleared after being LOOPS`() = runTest {
-        val viewModel = createViewModel()
-        loopRegionFlow.value = LoopRegion(1000L, 5000L)
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        viewModel.uiState.test {
-            awaitItem() // current state (LOOPS)
-
-            loopRegionFlow.value = null
+    fun `showWaveform is false when overlayMode is NONE`() =
+        runTest {
+            val viewModel = createViewModel()
             testDispatcher.scheduler.advanceUntilIdle()
 
-            val state = awaitItem()
-            assertEquals(OverlayMode.NONE, state.overlayMode)
+            assertFalse(viewModel.uiState.value.showWaveform)
         }
-    }
 
     @Test
-    fun `showWaveform is true when overlayMode is LOOPS`() = runTest {
-        val viewModel = createViewModel()
-        testDispatcher.scheduler.advanceUntilIdle()
+    fun `dismissWaveform clears the loop and sets overlayMode to NONE`() =
+        runTest {
+            val viewModel = createViewModel()
+            loopRegionFlow.value = LoopRegion(1000L, 5000L)
+            testDispatcher.scheduler.advanceUntilIdle()
 
-        loopRegionFlow.value = LoopRegion(1000L, 5000L)
-        testDispatcher.scheduler.advanceUntilIdle()
+            viewModel.dismissWaveform()
+            testDispatcher.scheduler.advanceUntilIdle()
 
-        assertTrue(viewModel.uiState.value.showWaveform)
-    }
-
-    @Test
-    fun `showWaveform is false when overlayMode is NONE`() = runTest {
-        val viewModel = createViewModel()
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        assertFalse(viewModel.uiState.value.showWaveform)
-    }
-
-    @Test
-    fun `dismissWaveform clears the loop and sets overlayMode to NONE`() = runTest {
-        val viewModel = createViewModel()
-        loopRegionFlow.value = LoopRegion(1000L, 5000L)
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        viewModel.dismissWaveform()
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        verify { playbackManager.clearLoopRegion() }
-        assertEquals(OverlayMode.NONE, viewModel.uiState.value.overlayMode)
-        assertFalse(viewModel.uiState.value.showWaveform)
-    }
+            verify { playbackManager.clearLoopRegion() }
+            assertEquals(OverlayMode.NONE, viewModel.uiState.value.overlayMode)
+            assertFalse(viewModel.uiState.value.showWaveform)
+        }
 }

--- a/app/src/test/java/com/rehearsall/ui/playback/components/WaveformViewTest.kt
+++ b/app/src/test/java/com/rehearsall/ui/playback/components/WaveformViewTest.kt
@@ -4,7 +4,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class WaveformViewTest {
-
     private val tolerance = 0.001f
 
     @Test

--- a/app/src/test/java/com/rehearsall/ui/playlist/PlaylistViewModelReorderTest.kt
+++ b/app/src/test/java/com/rehearsall/ui/playlist/PlaylistViewModelReorderTest.kt
@@ -4,8 +4,6 @@ import androidx.lifecycle.SavedStateHandle
 import com.rehearsall.data.repository.PlaylistRepository
 import com.rehearsall.domain.model.Playlist
 import com.rehearsall.domain.model.PlaylistItem
-import java.time.Instant
-import com.rehearsall.playback.PlaybackManager
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -21,10 +19,10 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
+import java.time.Instant
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class PlaylistViewModelReorderTest {
-
     private val testDispatcher = StandardTestDispatcher()
 
     private lateinit var playlistRepository: PlaylistRepository
@@ -32,16 +30,21 @@ class PlaylistViewModelReorderTest {
 
     private val playlistId = 42L
     private val now = Instant.EPOCH
-    private val playlist = Playlist(
-        id = playlistId,
-        name = "Test Playlist",
-        trackCount = 3,
-        totalDurationMs = 0L,
-        createdAt = now,
-        updatedAt = now,
-    )
+    private val playlist =
+        Playlist(
+            id = playlistId,
+            name = "Test Playlist",
+            trackCount = 3,
+            totalDurationMs = 0L,
+            createdAt = now,
+            updatedAt = now,
+        )
 
-    private fun makeItem(id: Long, name: String, order: Int) = PlaylistItem(
+    private fun makeItem(
+        id: Long,
+        name: String,
+        order: Int,
+    ) = PlaylistItem(
         id = id,
         playlistId = playlistId,
         audioFileId = id,
@@ -61,16 +64,18 @@ class PlaylistViewModelReorderTest {
     fun setup() {
         Dispatchers.setMain(testDispatcher)
 
-        playlistRepository = mockk(relaxed = true) {
-            coEvery { getById(playlistId) } returns playlist
-            every { getPlaylistItems(playlistId) } returns flowOf(listOf(item1, item2, item3))
-        }
+        playlistRepository =
+            mockk(relaxed = true) {
+                coEvery { getById(playlistId) } returns playlist
+                every { getPlaylistItems(playlistId) } returns flowOf(listOf(item1, item2, item3))
+            }
 
-        viewModel = PlaylistViewModel(
-            savedStateHandle = SavedStateHandle(mapOf("playlistId" to playlistId)),
-            playlistRepository = playlistRepository,
-            playbackManager = mockk(relaxed = true),
-        )
+        viewModel =
+            PlaylistViewModel(
+                savedStateHandle = SavedStateHandle(mapOf("playlistId" to playlistId)),
+                playlistRepository = playlistRepository,
+                playbackManager = mockk(relaxed = true),
+            )
 
         testDispatcher.scheduler.advanceUntilIdle()
     }
@@ -81,65 +86,70 @@ class PlaylistViewModelReorderTest {
     }
 
     @Test
-    fun `initial state loads items in order`() = runTest {
-        val state = viewModel.uiState.value as PlaylistUiState.Loaded
-        assertEquals(listOf(item1, item2, item3), state.items)
-    }
+    fun `initial state loads items in order`() =
+        runTest {
+            val state = viewModel.uiState.value as PlaylistUiState.Loaded
+            assertEquals(listOf(item1, item2, item3), state.items)
+        }
 
     @Test
-    fun `reorderItems calls repository with updated order pairs`() = runTest {
-        // Move index 0 (Alpha) to index 2 (after Gamma)
-        // Result should be: Beta(0), Gamma(1), Alpha(2)
-        viewModel.reorderItems(fromIndex = 0, toIndex = 2)
-        testDispatcher.scheduler.advanceUntilIdle()
+    fun `reorderItems calls repository with updated order pairs`() =
+        runTest {
+            // Move index 0 (Alpha) to index 2 (after Gamma)
+            // Result should be: Beta(0), Gamma(1), Alpha(2)
+            viewModel.reorderItems(fromIndex = 0, toIndex = 2)
+            testDispatcher.scheduler.advanceUntilIdle()
 
-        coVerify {
-            playlistRepository.reorderItems(
-                playlistId = playlistId,
-                items = listOf(item2.id to 0, item3.id to 1, item1.id to 2),
-            )
+            coVerify {
+                playlistRepository.reorderItems(
+                    playlistId = playlistId,
+                    items = listOf(item2.id to 0, item3.id to 1, item1.id to 2),
+                )
+            }
         }
-    }
 
     @Test
-    fun `reorderItems moving down one step calls repository correctly`() = runTest {
-        // Move index 0 (Alpha) to index 1 → Beta(0), Alpha(1), Gamma(2)
-        viewModel.reorderItems(fromIndex = 0, toIndex = 1)
-        testDispatcher.scheduler.advanceUntilIdle()
+    fun `reorderItems moving down one step calls repository correctly`() =
+        runTest {
+            // Move index 0 (Alpha) to index 1 → Beta(0), Alpha(1), Gamma(2)
+            viewModel.reorderItems(fromIndex = 0, toIndex = 1)
+            testDispatcher.scheduler.advanceUntilIdle()
 
-        coVerify {
-            playlistRepository.reorderItems(
-                playlistId = playlistId,
-                items = listOf(item2.id to 0, item1.id to 1, item3.id to 2),
-            )
+            coVerify {
+                playlistRepository.reorderItems(
+                    playlistId = playlistId,
+                    items = listOf(item2.id to 0, item1.id to 1, item3.id to 2),
+                )
+            }
         }
-    }
 
     @Test
-    fun `reorderItems moving item to same index does not crash`() = runTest {
-        viewModel.reorderItems(fromIndex = 1, toIndex = 1)
-        testDispatcher.scheduler.advanceUntilIdle()
+    fun `reorderItems moving item to same index does not crash`() =
+        runTest {
+            viewModel.reorderItems(fromIndex = 1, toIndex = 1)
+            testDispatcher.scheduler.advanceUntilIdle()
 
-        // Should still call through — no error
-        coVerify {
-            playlistRepository.reorderItems(
-                playlistId = playlistId,
-                items = any(),
-            )
+            // Should still call through — no error
+            coVerify {
+                playlistRepository.reorderItems(
+                    playlistId = playlistId,
+                    items = any(),
+                )
+            }
         }
-    }
 
     @Test
-    fun `reorderItems moving last item to first position`() = runTest {
-        // Move index 2 (Gamma) to index 0 → Gamma(0), Alpha(1), Beta(2)
-        viewModel.reorderItems(fromIndex = 2, toIndex = 0)
-        testDispatcher.scheduler.advanceUntilIdle()
+    fun `reorderItems moving last item to first position`() =
+        runTest {
+            // Move index 2 (Gamma) to index 0 → Gamma(0), Alpha(1), Beta(2)
+            viewModel.reorderItems(fromIndex = 2, toIndex = 0)
+            testDispatcher.scheduler.advanceUntilIdle()
 
-        coVerify {
-            playlistRepository.reorderItems(
-                playlistId = playlistId,
-                items = listOf(item3.id to 0, item1.id to 1, item2.id to 2),
-            )
+            coVerify {
+                playlistRepository.reorderItems(
+                    playlistId = playlistId,
+                    items = listOf(item3.id to 0, item1.id to 1, item2.id to 2),
+                )
+            }
         }
-    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,4 +4,13 @@ plugins {
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.hilt) apply false
+    alias(libs.plugins.ktlint)
+}
+
+subprojects {
+    apply(plugin = "org.jlleitschuh.gradle.ktlint")
+
+    configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
+        android.set(true)
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ appcompat = "1.7.0"
 material3-window-size = "1.3.1"
 material3-adaptive = "1.3.1"
 reorderable = "2.4.0"
+ktlint = "12.1.2"
 
 # Testing
 junit = "4.13.2"
@@ -103,3 +104,4 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }


### PR DESCRIPTION
## Summary

- Adds `org.jlleitschuh.gradle.ktlint` plugin (v12.1.2) for consistent Kotlin code formatting
- Applied to all subprojects with Android mode enabled
- CI runs `ktlintCheck` before Android lint — fails the build on formatting violations
- Developers run `./gradlew ktlintFormat` locally to auto-fix

## Test plan

- [ ] CI passes `ktlintCheck` step (or produces actionable formatting errors to fix)
- [ ] `./gradlew ktlintFormat` auto-fixes any violations locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)