### PR TITLE
fix: resolve deprecated PlaylistAdd icon and compileSdk 36 warnings

### DIFF
--- a/app/src/main/java/com/rehearsall/ui/filelist/FileListScreen.kt
+++ b/app/src/main/java/com/rehearsall/ui/filelist/FileListScreen.kt
@@ -27,7 +27,7 @@ import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.PlaylistAdd
+import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
@@ -452,7 +452,7 @@ private fun SelectionBar(
             enabled = selectedCount > 0,
         ) {
             Icon(
-                imageVector = Icons.Default.PlaylistAdd,
+                imageVector = Icons.AutoMirrored.Filled.PlaylistAdd,
                 contentDescription = "Add selected to playlist",
                 tint = MaterialTheme.colorScheme.onSecondaryContainer,
             )

--- a/app/src/main/java/com/rehearsall/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/rehearsall/ui/library/LibraryScreen.kt
@@ -29,7 +29,7 @@ import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.PlaylistAdd
+import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
@@ -443,7 +443,7 @@ private fun SelectionBar(
             enabled = selectedCount > 0,
         ) {
             Icon(
-                imageVector = Icons.Default.PlaylistAdd,
+                imageVector = Icons.AutoMirrored.Filled.PlaylistAdd,
                 contentDescription = "Add selected to playlist",
                 tint = MaterialTheme.colorScheme.onSecondaryContainer,
             )
@@ -557,7 +557,7 @@ private fun AudioFileCard(
                         DropdownMenuItem(
                             text = { Text("Add to Playlist") },
                             onClick = { showMenu = false; onAddToPlaylist() },
-                            leadingIcon = { Icon(Icons.Default.PlaylistAdd, null) },
+                            leadingIcon = { Icon(Icons.AutoMirrored.Filled.PlaylistAdd, null) },
                         )
                         DropdownMenuItem(
                             text = { Text("File Details") },

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,3 +11,6 @@ kotlin.code.style=official
 
 # Non-transitive R classes (recommended for build performance)
 android.nonTransitiveRClass=true
+
+# Suppress compileSdk 36 warning until AGP adds official support
+android.suppressUnsupportedCompileSdk=36


### PR DESCRIPTION
## Summary
- Replace deprecated `Icons.Filled.PlaylistAdd` with `Icons.AutoMirrored.Filled.PlaylistAdd` in FileListScreen and LibraryScreen
- Add `android.suppressUnsupportedCompileSdk=36` to gradle.properties until AGP officially supports SDK 36
- Build now completes with zero warnings

Closes #41

## Test plan
- [x] `./gradlew assembleDebug` passes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)